### PR TITLE
chore(Makefile): rustfmt -> cargo fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ fmtsql:
 	find migrations -type f | xargs -L 1 pg_format --type-case 2 -i
 
 fmtrs:
-	rustfmt src/*
+	cargo fmt
 
 fmt: fmtproto fmtsql fmtrs
 


### PR DESCRIPTION
according to https://github.com/rust-lang/rustfmt#rusts-editions

> Rustfmt is able to pick up the edition used by reading the Cargo.toml file if executed through the Cargo's formatting tool cargo fmt. Otherwise, the edition needs to be specified in rustfmt.toml, e.g., with edition = "2018".


and https://github.com/rust-lang/rustfmt#running-cargo-fmt

> cargo fmt works on both single-crate projects and cargo workspaces. 