### PR TITLE
fixes and improvments for issue #29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,6 @@ num_enum = "0.5.1"
 tonic = "0.3.1"
 actix-web = "3.3.2"
 
-[target.'cfg(windows)'.dependencies]
-rdkafka = { version = "0.24.0", features = ["dynamic_linking"] }
-
 [build-dependencies]
 prost = "0.6.1"
 tonic-build = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ num_enum = "0.5.1"
 tonic = "0.3.1"
 actix-web = "3.3.2"
 
+[target.'cfg(windows)'.dependencies]
+rdkafka = { version = "0.24.0", features = ["dynamic_linking"] }
+
 [build-dependencies]
 prost = "0.6.1"
 tonic-build = "0.3.1"


### PR DESCRIPTION
Fixing for this issue is not so clear like it first seems: we need a explicitly "blocking the world"  (more precisely: blocking the rpc) being induced. Some terms should be considered:

1. The single-thread nature of current grpc, implied with tonic and running with tonic::transport, can be only a implicitly contract achieve by a tokio-runtime with basic_scheduler. i.e. You DEFINITELY CAN NOT achieve this with a  more common threaded-scheduler.

2. Because of 1., it is impossible to induce correct "stop the world" behavior among a single-threading async framework (a. you can not just block its running in your code; b. you can not expect the framework schedule tasks in sequence as you wish to)

To resolve the issue, it should be inevitable to bring one more tokio-runtime into the scheme, running the task require STW in the later runtime and blocking the first one (which is running the gprc tasks) at the same time. Under the fix, I make the later runtime visible inside controller to pave for the later improvement for a better async fashion throughout the whole project (I talked about mostly the DatabaseWriter). And this also make our STW implement and the code in main.rs more neatly.
