### PR TITLE
Issue/25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ tonic-build = "0.3.1"
 [[bin]]
 name = "rest_api"
 path = "src/rest_api.rs"
+
+[features]
+windows_build = ["rdkafka/dynamic_linking"]

--- a/src/database.rs
+++ b/src/database.rs
@@ -126,7 +126,7 @@ where
 
             if !entries.is_empty() {
                 //print the insert sql statement
-                println!("{}", sqlxextend::InsertTable::sql_statement::<U>());
+                println!("{}", <InsertTable as CommonSQLQuery<U, sqlx::Postgres>>::sql_statement());
                 for u in entries.drain(0..) {
                     loop {
                         match rt.block_on(u.sql_query(&mut conn)) {

--- a/src/database.rs
+++ b/src/database.rs
@@ -24,7 +24,7 @@ pub struct DatabaseWriterStatus {
 pub struct DatabaseWriter<TableTarget, U = TableTarget>
 where
     TableTarget: for<'r> SqlxAction<'r, sqlxextend::InsertTable, DbType>,
-    TableTarget: From<U>,
+    TableTarget: From<U> + TableSchemas,
     U: std::clone::Clone + Send,
 {
     pub sender: crossbeam_channel::Sender<U>,
@@ -54,7 +54,7 @@ where
 impl<U> DatabaseWriter<U, U>
 where
     U: Send + std::marker::Sync + std::fmt::Debug + std::clone::Clone,
-    U: 'static,
+    U: 'static + TableSchemas,
     U: for<'r> SqlxAction<'r, sqlxextend::InsertTable, DbType>,
 {
     pub fn new(config: &DatabaseWriterConfig) -> Result<DatabaseWriter<U, U>> {
@@ -126,29 +126,29 @@ where
 
             if !entries.is_empty() {
                 //print the insert sql statement
-                println!("{}", <InsertTable as CommonSQLQuery<U, sqlx::Postgres>>::sql_statement());
-                for u in entries.drain(0..) {
-                    loop {
-                        match rt.block_on(u.sql_query(&mut conn)) {
-                            Ok(_) => {
-                                break;
-                            }
-                            Err(sqlx::Error::Database(dberr)) => {
-                                if let Some(code) = dberr.code() {
-                                    if code == "23505" {
-                                        println!("Warning, exec sql duplicated entry, break");
-                                        break;
-                                    }
+                println!("{} (by batch for {} entries)", 
+                    <InsertTable as CommonSQLQuery<U, sqlx::Postgres>>::sql_statement(),
+                    entries.len());
+                loop {
+                    match rt.block_on(InsertTableBatch::sql_query_fine(entries.as_slice(), &mut conn)) {
+                        Ok(_) => {
+                            break;
+                        }
+                        Err(sqlx::Error::Database(dberr)) => {
+                            if let Some(code) = dberr.code() {
+                                if code == "23505" {
+                                    println!("Warning, exec sql duplicated entry, break");
+                                    break;
                                 }
-                                println!("exec sql: db fail: {}. retry.", dberr.message());
                             }
-                            Err(e) => {
-                                println!("exec sql:  fail: {}. retry.", e.to_string());
-                                std::thread::sleep(std::time::Duration::from_secs(1));
-                            }
+                            println!("exec sql: db fail: {}. retry.", dberr.message());
+                        }
+                        Err(e) => {
+                            println!("exec sql:  fail: {}. retry.", e.to_string());
+                            std::thread::sleep(std::time::Duration::from_secs(1));
                         }
                     }
-                }
+                }                
             }
         }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -126,9 +126,11 @@ where
 
             if !entries.is_empty() {
                 //print the insert sql statement
-                println!("{} (by batch for {} entries)", 
+                println!(
+                    "{} (by batch for {} entries)",
                     <InsertTable as CommonSQLQuery<U, sqlx::Postgres>>::sql_statement(),
-                    entries.len());
+                    entries.len()
+                );
                 loop {
                     match rt.block_on(InsertTableBatch::sql_query_fine(entries.as_slice(), &mut conn)) {
                         Ok(_) => {
@@ -148,7 +150,7 @@ where
                             std::thread::sleep(std::time::Duration::from_secs(1));
                         }
                     }
-                }                
+                }
             }
         }
 


### PR DESCRIPTION
Resolve #25: batch inserting

For any type T can execute insert querying, [T] can also execute a "batch" insert, using a big prepare statement like `insert into my_table value ($1,$2,$3), ($4,$5,$6), ...`.

Now the batch inserting do not need to care about the actual size of array: the implement automatically split it into a group of sub arrays, whose length is right 2^n (n can be from 3 to 10) or less than 8. For saving the number of cached preparations.

This PR also provide better code in sqlextend module: abandon the async trait and replace it by returning the sqlx-fashioned pinned futures, and much better code for generic and trait bounding.
