### PR TITLE
db: for every table, change writer thread num from 1 to 4

### DIFF
--- a/examples/js/stress.js
+++ b/examples/js/stress.js
@@ -67,7 +67,7 @@ async function stressTest({ parallel, interval, repeat }) {
 
 async function main() {
   try {
-    await stressTest({ parallel: 100, interval: 100, repeat: 500 });
+    await stressTest({ parallel: 100, interval: 50, repeat: 1000 });
   } catch (error) {
     console.error("Catched error:", error);
   }

--- a/examples/js/stress.js
+++ b/examples/js/stress.js
@@ -19,7 +19,7 @@ async function stressTest({ parallel, interval, repeat }) {
   const tradeCountBefore = (await marketSummary()).find(
     item => item.name == market
   ).trade_count;
-  await depositAssets({ BTC: "100000", ETH: "50000" });
+  await depositAssets({ BTC: "1000000", ETH: "500000" });
 
   await printBalance();
   const startTime = new Date();
@@ -67,7 +67,7 @@ async function stressTest({ parallel, interval, repeat }) {
 
 async function main() {
   try {
-    await stressTest({ parallel: 10, interval: 1000, repeat: 10 });
+    await stressTest({ parallel: 100, interval: 100, repeat: 500 });
   } catch (error) {
     console.error("Catched error:", error);
   }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -138,7 +138,7 @@ impl BalanceManager {
     pub fn set_by_key(&mut self, key: BalanceMapKey, amount: &Decimal) {
         debug_assert!(amount.is_sign_positive());
         let amount = amount.round_dp(self.asset_manager.asset_prev(&key.asset));
-        log::debug!("set balance: {:?}, {}", key, amount);
+        //log::debug!("set balance: {:?}, {}", key, amount);
         self.balances.insert(key, amount);
     }
     pub fn add(&mut self, user_id: u32, balance_type: BalanceType, asset: &str, amount: &Decimal) -> Decimal {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -56,7 +56,7 @@ impl Controller {
             DatabaseHistoryWriter::new(&DatabaseWriterConfig {
                 database_url: settings.db_history.clone(),
                 run_daemon: true,
-                inner_buffer_size: 1024,
+                inner_buffer_size: 8192,
             })
             .unwrap(),
         ));
@@ -83,7 +83,7 @@ impl Controller {
         let log_handler = OperationLogSender::new(&DatabaseWriterConfig {
             database_url: settings.db_log.clone(),
             run_daemon: true,
-            inner_buffer_size: 1024,
+            inner_buffer_size: 8192,
         })
         .unwrap();
         Controller {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -56,7 +56,7 @@ impl Controller {
             DatabaseHistoryWriter::new(&DatabaseWriterConfig {
                 database_url: settings.db_history.clone(),
                 run_daemon: true,
-                inner_buffer_size: 1000,
+                inner_buffer_size: 1024,
             })
             .unwrap(),
         ));
@@ -83,7 +83,7 @@ impl Controller {
         let log_handler = OperationLogSender::new(&DatabaseWriterConfig {
             database_url: settings.db_log.clone(),
             run_daemon: true,
-            inner_buffer_size: 1000,
+            inner_buffer_size: 1024,
         })
         .unwrap();
         Controller {

--- a/src/message.rs
+++ b/src/message.rs
@@ -157,7 +157,7 @@ impl KafkaMessageSender {
                     }
                     Err(RecvTimeoutError::Timeout) => {}
                     Err(RecvTimeoutError::Disconnected) => {
-                        println!("kafka producer disconnected");
+                        log::info!("kafka producer disconnected");
                         break;
                     }
                 }
@@ -199,8 +199,8 @@ pub struct ChannelMessageManager {
 
 impl ChannelMessageManager {
     fn push_message(&self, message: String, topic_name: &'static str) {
-        println!("KAFKA: push {} message: {}", topic_name, message);
-        self.sender.try_send((topic_name, message)).unwrap();
+        //log::debug!("KAFKA: push {} message: {}", topic_name, message);
+        //self.sender.try_send((topic_name, message)).unwrap();
     }
     pub fn is_block(&self) -> bool {
         self.sender.len() >= (self.sender.capacity().unwrap() as f64 * 0.9) as usize

--- a/src/message.rs
+++ b/src/message.rs
@@ -101,7 +101,7 @@ impl KafkaMessageSender {
                 list.push_back(message.to_string());
                 return Ok(());
             }
-            return Err(anyhow!("kafka push err {}", result));
+            return Err(anyhow!("kafka push err"));
         }
         Ok(())
     }

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -13,7 +13,7 @@ impl Sequencer {
     }
     pub fn next_order_id(&mut self) -> u64 {
         self.order_id += 1;
-        log::debug!("next_order_id {}", self.order_id);
+        //log::debug!("next_order_id {}", self.order_id);
         self.order_id
     }
     pub fn next_trade_id(&mut self) -> u64 {

--- a/src/sqlxextend.rs
+++ b/src/sqlxextend.rs
@@ -252,23 +252,27 @@ impl InsertTableBatch {
 
         let mut qr_vm = qr_v;
 
-        //we split the whole array into a group arrys with lengh = 2^n (or less 8)
-        //to reduce the number of cached prepare statement (which is default)
-        while qr_vm.len() >= 8 {
-            for n in (3..11).rev() {
-                if qr_vm.len() >= (1 << n) {
-                    let qr_used = &qr_vm[..(1 << n)];
-                    qr_vm = &qr_vm[(1 << n)..];
-                    println!("batch {} queries", qr_used.len());
-                    Self::sql_query(qr_used, &mut *conn).await?;
-                    break;
+        if true {
+            Self::sql_query(&qr_vm, &mut *conn).await?;
+        } else {
+            //we split the whole array into a group arrys with lengh = 2^n (or less 8)
+            //to reduce the number of cached prepare statement (which is default)
+            while qr_vm.len() >= 8 {
+                for n in (3..11).rev() {
+                    if qr_vm.len() >= (1 << n) {
+                        let qr_used = &qr_vm[..(1 << n)];
+                        qr_vm = &qr_vm[(1 << n)..];
+                        println!("batch {} queries", qr_used.len());
+                        Self::sql_query(qr_used, &mut *conn).await?;
+                        break;
+                    }
                 }
             }
-        }
 
-        if !qr_vm.is_empty() {
-            println!("batch {} queries", qr_vm.len());
-            Self::sql_query(qr_vm, &mut *conn).await?;
+            if !qr_vm.is_empty() {
+                println!("batch {} queries", qr_vm.len());
+                Self::sql_query(qr_vm, &mut *conn).await?;
+            }
         }
 
         Ok(SqlResultExt::Done)

--- a/src/sqlxextend.rs
+++ b/src/sqlxextend.rs
@@ -252,7 +252,7 @@ impl InsertTableBatch {
 
         let mut qr_vm = qr_v;
 
-        if true {
+        if false {
             Self::sql_query(&qr_vm, &mut *conn).await?;
         } else {
             //we split the whole array into a group arrys with lengh = 2^n (or less 8)


### PR DESCRIPTION
And I run the stress.js against the PQ inside docker compose on a m5.2xlarge EC2 instance with 200GiB gp2 SSD ( 600 IOPS ):


![image](https://user-images.githubusercontent.com/2833376/104203051-a796b000-5466-11eb-8500-52ec8bf3ed48.png)


( Changing parameters in stress.js may bring better results. But I did not try it )