### PR TITLE
fix: fix host.docker.internal in linux

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     restart: always
     volumes: 
       - ./configs/nginx.conf:/etc/nginx/conf.d/proxy.conf
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "8765:8765"
   grpcgateway:
@@ -14,6 +16,8 @@ services:
     restart: always
     volumes:
       - ../proto/exchange/matchengine.proto:/api.proto
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "50052:50052"
     command: api.proto -I ../../.. -p 50052 -g host.docker.internal:50051 -m /api    


### PR DESCRIPTION
it is a pity that there is no consistent method to access host inside docker <https://github.com/docker/for-linux/issues/264>