### PR TITLE
fix: write both to MQ and to DB by default 

### DIFF
--- a/examples/js/.gitignore
+++ b/examples/js/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 .env
-package-lock.json

--- a/examples/js/.gitignore
+++ b/examples/js/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+package-lock.json

--- a/examples/js/depoist.js
+++ b/examples/js/depoist.js
@@ -1,0 +1,11 @@
+//deposit a lot to engine, so we would not encounter "balance not enough" failure
+
+import {  depositAssets } from "./util.mjs";
+
+async function main() {
+
+  //if I really had so much money ....
+  await depositAssets({ USDT: "10000000.0", ETH: "50000.0" });
+}
+
+main().catch(console.log);

--- a/src/matchengine/asset.rs
+++ b/src/matchengine/asset.rs
@@ -282,11 +282,13 @@ impl<T: HistoryWriter> PersistExector for DBAsPersistor<'_, T> {
 }
 
 impl<T1: PersistExector, T2: PersistExector> PersistExector for (T1, T2) {
-    fn real_persist(&self) -> bool {self.0.real_persist() || self.1.real_persist()}
+    fn real_persist(&self) -> bool {
+        self.0.real_persist() || self.1.real_persist()
+    }
     fn put_balance(&mut self, balance: BalanceHistory) {
         self.0.put_balance(balance.clone());
         self.1.put_balance(balance);
-    }   
+    }
 }
 
 pub(super) fn persistor_for_message<T: MessageManager>(messenger: &mut T) -> MessengerAsPersistor<'_, T> {

--- a/src/matchengine/asset.rs
+++ b/src/matchengine/asset.rs
@@ -281,6 +281,14 @@ impl<T: HistoryWriter> PersistExector for DBAsPersistor<'_, T> {
     }
 }
 
+impl<T1: PersistExector, T2: PersistExector> PersistExector for (T1, T2) {
+    fn real_persist(&self) -> bool {self.0.real_persist() || self.1.real_persist()}
+    fn put_balance(&mut self, balance: BalanceHistory) {
+        self.0.put_balance(balance.clone());
+        self.1.put_balance(balance);
+    }   
+}
+
 pub(super) fn persistor_for_message<T: MessageManager>(messenger: &mut T) -> MessengerAsPersistor<'_, T> {
     MessengerAsPersistor(messenger)
 }

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -58,15 +58,10 @@ impl<'c> PersistorGen<'c> {
                 self.base.message_manager.as_mut().unwrap(),
                 market_tag,
             )),
-            PersistPolicy::Both => Box::new(
-                (
-                    market::persistor_for_db(&mut self.base.history_writer),
-                    market::persistor_for_message(
-                        self.base.message_manager.as_mut().unwrap(),
-                        market_tag,
-                    ),
-                )
-            ),
+            PersistPolicy::Both => Box::new((
+                market::persistor_for_db(&mut self.base.history_writer),
+                market::persistor_for_message(self.base.message_manager.as_mut().unwrap(), market_tag),
+            )),
         }
     }
 
@@ -75,12 +70,10 @@ impl<'c> PersistorGen<'c> {
             PersistPolicy::Dummy => Box::new(asset::DummyPersistor(false)),
             PersistPolicy::ToDB => Box::new(asset::persistor_for_db(&mut self.base.history_writer)),
             PersistPolicy::ToMessege => Box::new(asset::persistor_for_message(self.base.message_manager.as_mut().unwrap())),
-            PersistPolicy::Both => Box::new(
-                (
-                    asset::persistor_for_db(&mut self.base.history_writer),
-                    asset::persistor_for_message(self.base.message_manager.as_mut().unwrap()),
-                )
-            )
+            PersistPolicy::Both => Box::new((
+                asset::persistor_for_db(&mut self.base.history_writer),
+                asset::persistor_for_message(self.base.message_manager.as_mut().unwrap()),
+            )),
         }
     }
 }

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -33,6 +33,7 @@ use std::str::FromStr;
 #[derive(Copy, Clone)]
 enum PersistPolicy {
     Dummy,
+    Both,
     ToDB,
     ToMessege,
 }
@@ -57,6 +58,15 @@ impl<'c> PersistorGen<'c> {
                 self.base.message_manager.as_mut().unwrap(),
                 market_tag,
             )),
+            PersistPolicy::Both => Box::new(
+                (
+                    market::persistor_for_db(&mut self.base.history_writer),
+                    market::persistor_for_message(
+                        self.base.message_manager.as_mut().unwrap(),
+                        market_tag,
+                    ),
+                )
+            ),
         }
     }
 
@@ -65,6 +75,12 @@ impl<'c> PersistorGen<'c> {
             PersistPolicy::Dummy => Box::new(asset::DummyPersistor(false)),
             PersistPolicy::ToDB => Box::new(asset::persistor_for_db(&mut self.base.history_writer)),
             PersistPolicy::ToMessege => Box::new(asset::persistor_for_message(self.base.message_manager.as_mut().unwrap())),
+            PersistPolicy::Both => Box::new(
+                (
+                    asset::persistor_for_db(&mut self.base.history_writer),
+                    asset::persistor_for_message(self.base.message_manager.as_mut().unwrap()),
+                )
+            )
         }
     }
 }
@@ -144,7 +160,7 @@ impl Controller {
         .start_schedule(&main_pool)
         .unwrap();
 
-        let persist_policy = PersistPolicy::ToDB;
+        let persist_policy = PersistPolicy::Both;
 
         Controller {
             settings,
@@ -501,12 +517,13 @@ impl Controller {
             */
             // sqlx::query seems unable to handle multi statements, so `execute` is used here
 
+            let db_str = self.settings.db_log.clone();
             let down_cmd = include_str!("../../migrations/reset/down.sql");
             let up_cmd = include_str!("../../migrations/reset/up.sql");
-            let mut connection1 = self.dbg_pool.acquire().await?;
-            connection1.execute(down_cmd).await?;
-            let mut connection2 = self.dbg_pool.acquire().await?;
-            connection2.execute(up_cmd).await?;
+            let mut connection = ConnectionType::connect(&db_str).await?;
+            connection.execute(down_cmd).await?;
+            let mut connection = ConnectionType::connect(&db_str).await?;
+            connection.execute(up_cmd).await?;
 
             //To workaround https://github.com/launchbadge/sqlx/issues/954: migrator is not Send
             let db_str = self.settings.db_log.clone();

--- a/src/matchengine/market.rs
+++ b/src/matchengine/market.rs
@@ -178,6 +178,18 @@ impl<T: MessageManager> PersistExector for MessengerAsPersistor<'_, T> {
     }
 }
 
+impl<T1: PersistExector, T2: PersistExector> PersistExector for (T1, T2) {
+    fn real_persist(&self) -> bool {self.0.real_persist() || self.1.real_persist()}
+    fn put_order(&mut self, order: &Order, at_step: OrderEventType) {
+        self.0.put_order(order, at_step);
+        self.1.put_order(order, at_step);
+    }
+    fn put_trade(&mut self, trade: &Trade) {
+        self.0.put_trade(trade);
+        self.1.put_trade(trade);
+    }    
+}
+
 pub(super) struct DBAsPersistor<'a, T>(&'a mut T);
 
 impl<T: HistoryWriter> PersistExector for DBAsPersistor<'_, T> {

--- a/src/matchengine/market.rs
+++ b/src/matchengine/market.rs
@@ -179,7 +179,9 @@ impl<T: MessageManager> PersistExector for MessengerAsPersistor<'_, T> {
 }
 
 impl<T1: PersistExector, T2: PersistExector> PersistExector for (T1, T2) {
-    fn real_persist(&self) -> bool {self.0.real_persist() || self.1.real_persist()}
+    fn real_persist(&self) -> bool {
+        self.0.real_persist() || self.1.real_persist()
+    }
     fn put_order(&mut self, order: &Order, at_step: OrderEventType) {
         self.0.put_order(order, at_step);
         self.1.put_order(order, at_step);
@@ -187,7 +189,7 @@ impl<T1: PersistExector, T2: PersistExector> PersistExector for (T1, T2) {
     fn put_trade(&mut self, trade: &Trade) {
         self.0.put_trade(trade);
         self.1.put_trade(trade);
-    }    
+    }
 }
 
 pub(super) struct DBAsPersistor<'a, T>(&'a mut T);


### PR DESCRIPTION
* Restore the default behavior: output history to both mq and db

* Fix issues ind debug_reset: when use conneciton pool instead of a sole connection, it seems the up-statement is not executed so wired things rise after one debug_reset is called. Now it get fixed.