### PR TITLE
Feature: persistor for all history

### DIFF
--- a/src/bin/matchengine.rs
+++ b/src/bin/matchengine.rs
@@ -45,7 +45,7 @@ async fn prepare() -> anyhow::Result<Controller> {
 
 async fn grpc_run(stub: Controller) -> Result<(), Box<dyn std::error::Error>> {
     let addr = "0.0.0.0:50051".parse().unwrap();
-    let grpc = GrpcHandler::new(stub);
+    let mut grpc = GrpcHandler::new(stub);
     log::info!("Starting gprc service");
 
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();

--- a/src/bin/persistor.rs
+++ b/src/bin/persistor.rs
@@ -10,7 +10,7 @@ use types::{DbType};
 
 use rdkafka::consumer::{StreamConsumer};
 
-use message::persist::MIGRATOR;
+use message::persist::{MIGRATOR, TopicConfig};
 
 fn main() {
     dotenv::dotenv().ok();
@@ -53,12 +53,14 @@ fn main() {
         .start_schedule(&pool)
         .unwrap();
 
+        let trade_cfg = TopicConfig::<message::Trade>::new(message::TRADES_TOPIC)
+            .persist_to(&persistor)
+            .persist_to(&persistor);
+
         loop {
             let cr_main = message::consumer::SimpleConsumer::new(&consumer)
-                .add_topic(
-                    message::TRADES_TOPIC,
-                    message::persist::MsgDataPersistor::<_, message::Trade>::new(&persistor),
-                )
+                .add_topic_config(&trade_cfg)
+//                .add_topic(message::TRADES_TOPIC, MsgDataPersistor::new(&persistor).handle_message::<message::Trade>())
                 .unwrap();
 
             tokio::select! {

--- a/src/bin/persistor.rs
+++ b/src/bin/persistor.rs
@@ -4,13 +4,14 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::single_char_pattern)]
 
+use std::pin::Pin;
 use database::{DatabaseWriter, DatabaseWriterConfig};
 use dingir_exchange::{config, database, message, models, types};
 use types::{DbType};
 
 use rdkafka::consumer::{StreamConsumer};
 
-use message::persist::{MIGRATOR, TopicConfig};
+use message::persist::{self, MIGRATOR, TopicConfig};
 
 fn main() {
     dotenv::dotenv().ok();
@@ -27,17 +28,20 @@ fn main() {
         .build()
         .expect("build runtime");
 
-    let consumer: StreamConsumer = rdkafka::config::ClientConfig::new()
+    rt.block_on(async move {
+
+        let consumer: StreamConsumer = rdkafka::config::ClientConfig::new()
         .set("bootstrap.servers", &settings.brokers)
         .set("group.id", &settings.consumer_group)
         .set("enable.partition.eof", "false")
         .set("session.timeout.ms", "6000")
-        .set("enable.auto.commit", "true")
+        .set("enable.auto.commit", "false")
         .set("auto.offset.reset", "earliest")
         .create()
         .unwrap();
 
-    rt.block_on(async move {
+        let consumer = std::sync::Arc::new(consumer);
+
         let pool = sqlx::Pool::<DbType>::connect(&settings.db_history).await.unwrap();
 
         MIGRATOR
@@ -45,23 +49,55 @@ fn main() {
             .await
             .ok();
 
-        let persistor: DatabaseWriter<models::TradeRecord> = DatabaseWriter::new(&DatabaseWriterConfig {
+        let write_config = DatabaseWriterConfig {
             spawn_limit: 4,
             apply_benchmark: true,
             capability_limit: 8192,
-        })
+        };
+
+        let persistor_kline: DatabaseWriter<models::TradeRecord> = DatabaseWriter::new(&write_config)
         .start_schedule(&pool)
         .unwrap();
 
+        //following is equal to writers in history.rs
+        let persistor_trade: DatabaseWriter<models::TradeHistory> = DatabaseWriter::new(&write_config)
+        .start_schedule(&pool)
+        .unwrap();
+
+        let persistor_order: DatabaseWriter<models::OrderHistory> = DatabaseWriter::new(&write_config)
+        .start_schedule(&pool)
+        .unwrap();
+
+        let persistor_balance: DatabaseWriter<models::BalanceHistory> = DatabaseWriter::new(&write_config)
+        .start_schedule(&pool)
+        .unwrap();
+
+
         let trade_cfg = TopicConfig::<message::Trade>::new(message::TRADES_TOPIC)
-            .persist_to(&persistor)
-            .persist_to(&persistor);
+            .persist_to(&persistor_kline)
+            .persist_to(&persistor_trade).with_tr::<persist::AskTrade>()
+            .persist_to(&persistor_trade).with_tr::<persist::BidTrade>();
+        
+        let order_cfg = TopicConfig::<message::OrderMessage>::new(message::ORDERS_TOPIC)
+            .persist_to(&persistor_order);
+        
+        let balance_cfg = TopicConfig::<message::BalanceMessage>::new(message::BALANCES_TOPIC)
+            .persist_to(&persistor_balance);
+
+        let auto_commit = vec![
+            trade_cfg.auto_commit_start(consumer.clone()),
+            order_cfg.auto_commit_start(consumer.clone()),
+            balance_cfg.auto_commit_start(consumer.clone()),
+        ];
+        let consumer = consumer.as_ref();
 
         loop {
-            let cr_main = message::consumer::SimpleConsumer::new(&consumer)
-                .add_topic_config(&trade_cfg)
+            let cr_main = message::consumer::SimpleConsumer::new(consumer)
+                .add_topic_config(&trade_cfg).unwrap()
+                .add_topic_config(&order_cfg).unwrap()
+                .add_topic_config(&balance_cfg).unwrap()
 //                .add_topic(message::TRADES_TOPIC, MsgDataPersistor::new(&persistor).handle_message::<message::Trade>())
-                .unwrap();
+                ;
 
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {
@@ -75,6 +111,19 @@ fn main() {
             }
         }
 
-        persistor.finish().await.unwrap();
+        tokio::try_join!(
+            persistor_kline.finish(),
+            persistor_trade.finish(),
+            persistor_order.finish(),
+            persistor_balance.finish(),
+        ).expect("all persistor should success finish");
+        let final_commits : Vec<Pin<Box<dyn std::future::Future<Output=()> + Send>>>
+            = auto_commit
+                .into_iter()
+                .map(|ac| -> Pin<Box<dyn std::future::Future<Output=()> + Send>>
+                    {Box::pin(ac.final_commit(consumer))})
+                .collect();
+        futures::future::join_all(final_commits).await;
+        //auto_commit.final_commit(consumer).await;
     })
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,10 +58,8 @@ pub enum PersistPolicy {
 
 use serde::de;
 
-impl<'de> de::Deserialize<'de> for PersistPolicy
-{
-    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error>
-    {
+impl<'de> de::Deserialize<'de> for PersistPolicy {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
 
         match s.as_ref() {
@@ -69,10 +67,9 @@ impl<'de> de::Deserialize<'de> for PersistPolicy
             "Db" | "db" | "DB" => Ok(PersistPolicy::ToDB),
             "Message" | "message" => Ok(PersistPolicy::ToMessage),
             "Dummy" | "dummy" => Ok(PersistPolicy::Dummy),
-            _ => Err(serde::de::Error::custom("unexpected specification for persist policy"))
-        }        
+            _ => Err(serde::de::Error::custom("unexpected specification for persist policy")),
+        }
     }
-    
 }
 
 #[derive(Debug, PartialEq, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,12 +48,40 @@ impl Default for Market {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum PersistPolicy {
+    Dummy,
+    Both,
+    ToDB,
+    ToMessage,
+}
+
+use serde::de;
+
+impl<'de> de::Deserialize<'de> for PersistPolicy
+{
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error>
+    {
+        let s = String::deserialize(deserializer)?;
+
+        match s.as_ref() {
+            "Both" | "both" => Ok(PersistPolicy::Both),
+            "Db" | "db" | "DB" => Ok(PersistPolicy::ToDB),
+            "Message" | "message" => Ok(PersistPolicy::ToMessage),
+            "Dummy" | "dummy" => Ok(PersistPolicy::Dummy),
+            _ => Err(serde::de::Error::custom("unexpected specification for persist policy"))
+        }        
+    }
+    
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
 #[serde(default)]
 pub struct Settings {
     pub debug: bool,
     pub db_log: String,
     pub db_history: String,
+    pub history_persist_policy: PersistPolicy,
     pub assets: Vec<Asset>,
     pub markets: Vec<Market>,
     pub brokers: String,
@@ -71,6 +99,7 @@ impl Default for Settings {
             debug: false,
             db_log: Default::default(),
             db_history: Default::default(),
+            history_persist_policy: PersistPolicy::Both,
             assets: Vec::new(),
             markets: Vec::new(),
             consumer_group: "kline_data_fetcher".to_string(),

--- a/src/matchengine/asset.rs
+++ b/src/matchengine/asset.rs
@@ -269,6 +269,8 @@ impl<T: MessageManager> PersistExector for MessengerAsPersistor<'_, T> {
             asset: balance.asset.clone(),
             business: balance.business.clone(),
             change: balance.change.to_string(),
+            balance: balance.balance.to_string(),
+            detail: balance.detail,
         });
     }
 }

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -147,7 +147,7 @@ impl Controller {
         .start_schedule(&main_pool)
         .unwrap();
 
-        let persist_policy = settings.history_persist_policy.clone();
+        let persist_policy = settings.history_persist_policy;
 
         Controller {
             settings,

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -30,13 +30,7 @@ use sqlx::Executor;
 use serde::Serialize;
 use std::str::FromStr;
 
-#[derive(Copy, Clone)]
-enum PersistPolicy {
-    Dummy,
-    Both,
-    ToDB,
-    ToMessege,
-}
+pub use config::PersistPolicy;
 
 pub struct Persistor {
     history_writer: DatabaseHistoryWriter,
@@ -54,7 +48,7 @@ impl<'c> PersistorGen<'c> {
         match self.policy {
             PersistPolicy::Dummy => Box::new(market::DummyPersistor(false)),
             PersistPolicy::ToDB => Box::new(market::persistor_for_db(&mut self.base.history_writer)),
-            PersistPolicy::ToMessege => Box::new(market::persistor_for_message(
+            PersistPolicy::ToMessage => Box::new(market::persistor_for_message(
                 self.base.message_manager.as_mut().unwrap(),
                 market_tag,
             )),
@@ -69,7 +63,7 @@ impl<'c> PersistorGen<'c> {
         match self.policy {
             PersistPolicy::Dummy => Box::new(asset::DummyPersistor(false)),
             PersistPolicy::ToDB => Box::new(asset::persistor_for_db(&mut self.base.history_writer)),
-            PersistPolicy::ToMessege => Box::new(asset::persistor_for_message(self.base.message_manager.as_mut().unwrap())),
+            PersistPolicy::ToMessage => Box::new(asset::persistor_for_message(self.base.message_manager.as_mut().unwrap())),
             PersistPolicy::Both => Box::new((
                 asset::persistor_for_db(&mut self.base.history_writer),
                 asset::persistor_for_message(self.base.message_manager.as_mut().unwrap()),
@@ -153,7 +147,7 @@ impl Controller {
         .start_schedule(&main_pool)
         .unwrap();
 
-        let persist_policy = PersistPolicy::Both;
+        let persist_policy = settings.history_persist_policy.clone();
 
         Controller {
             settings,

--- a/src/matchengine/dto.rs
+++ b/src/matchengine/dto.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 pub fn order_to_proto(o: &market::Order) -> OrderInfo {
     OrderInfo {
         id: o.id,
-        market: String::from(o.market),
+        market: String::from(&*o.market),
         order_type: if o.type_ == market::OrderType::LIMIT {
             OrderType::Limit as i32
         } else {

--- a/src/matchengine/history.rs
+++ b/src/matchengine/history.rs
@@ -44,7 +44,7 @@ impl DatabaseHistoryWriter {
     }
 }
 
-impl<'r> From<&'r market::Order> for models::OrderHistory{
+impl<'r> From<&'r market::Order> for models::OrderHistory {
     fn from(order: &'r market::Order) -> Self {
         models::OrderHistory {
             id: order.id as i64,

--- a/src/matchengine/history.rs
+++ b/src/matchengine/history.rs
@@ -44,6 +44,27 @@ impl DatabaseHistoryWriter {
     }
 }
 
+impl<'r> From<&'r market::Order> for models::OrderHistory{
+    fn from(order: &'r market::Order) -> Self {
+        models::OrderHistory {
+            id: order.id as i64,
+            create_time: FTimestamp(order.create_time).into(),
+            finish_time: FTimestamp(order.update_time).into(),
+            user_id: order.user as i32,
+            market: order.market.to_string(),
+            order_type: order.type_,
+            order_side: order.side,
+            price: order.price,
+            amount: order.amount,
+            taker_fee: order.taker_fee,
+            maker_fee: order.maker_fee,
+            finished_base: order.finished_base,
+            finished_quote: order.finished_quote,
+            finished_fee: order.finished_fee,
+        }
+    }
+}
+
 impl HistoryWriter for DatabaseHistoryWriter {
     fn is_block(&self) -> bool {
         self.balance_writer.is_block() || self.trade_writer.is_block() || self.order_writer.is_block()

--- a/src/matchengine/history.rs
+++ b/src/matchengine/history.rs
@@ -1,7 +1,7 @@
 use crate::database::{DatabaseWriter, DatabaseWriterConfig};
 use crate::market;
 use crate::models;
-use crate::types::Trade;
+use market::Trade;
 
 use crate::utils::FTimestamp;
 use anyhow::Result;

--- a/src/matchengine/market.rs
+++ b/src/matchengine/market.rs
@@ -71,6 +71,28 @@ pub struct Order {
     pub finished_fee: Decimal,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Trade {
+    pub id: u64,
+    pub timestamp: f64, // unix epoch timestamp,
+    pub market: String,
+    pub base: String,
+    pub quote: String,
+    pub price: rust_decimal::Decimal,
+    pub amount: rust_decimal::Decimal,
+    pub quote_amount: rust_decimal::Decimal,
+
+    pub ask_user_id: u32,
+    pub ask_order_id: u64,
+    pub ask_role: MarketRole, // take/make
+    pub ask_fee: rust_decimal::Decimal,
+
+    pub bid_user_id: u32,
+    pub bid_order_id: u64,
+    pub bid_role: MarketRole,
+    pub bid_fee: rust_decimal::Decimal,
+}
+
 impl Order {
     pub fn get_ask_key(&self) -> MarketKeyAsk {
         MarketKeyAsk {

--- a/src/matchengine/market.rs
+++ b/src/matchengine/market.rs
@@ -56,9 +56,10 @@ pub enum MarketString {
     Right(String),
 }
 
-impl From<&'static str> for MarketString
-{
-    fn from(str: &'static str) -> Self {MarketString::Left(str)}
+impl From<&'static str> for MarketString {
+    fn from(str: &'static str) -> Self {
+        MarketString::Left(str)
+    }
 }
 
 impl std::ops::Deref for MarketString {
@@ -71,10 +72,8 @@ impl std::ops::Deref for MarketString {
     }
 }
 
-impl serde::ser::Serialize for MarketString
-{
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    {
+impl serde::ser::Serialize for MarketString {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
             MarketString::Left(str) => serializer.serialize_str(*str),
             MarketString::Right(stri) => serializer.serialize_str(stri.as_str()),
@@ -82,14 +81,11 @@ impl serde::ser::Serialize for MarketString
     }
 }
 
-impl<'de> serde::de::Deserialize<'de> for MarketString
-{
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error>
-    {
+impl<'de> serde::de::Deserialize<'de> for MarketString {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
         Ok(MarketString::Right(s))
     }
-    
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -113,11 +109,9 @@ pub struct Order {
     pub finished_fee: Decimal,
 }
 
-fn de_market_string<'de, D: serde::de::Deserializer<'de>>(_deserializer: D) -> Result<&'static str, D::Error>
-{
+fn de_market_string<'de, D: serde::de::Deserializer<'de>>(_deserializer: D) -> Result<&'static str, D::Error> {
     Ok("Test")
 }
-
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Trade {

--- a/src/matchengine/persist.rs
+++ b/src/matchengine/persist.rs
@@ -138,7 +138,7 @@ pub async fn load_slice_from_db(conn: &mut ConnectionType, slice_id: i64, contro
                 side: order.order_side,
                 create_time: FTimestamp::from(&order.create_time).0,
                 update_time: FTimestamp::from(&order.update_time).0,
-                market: market.name,
+                market: market.name.into(),
                 user: order.user_id as u32,
                 price: order.price,
                 amount: order.amount,

--- a/src/matchengine/server.rs
+++ b/src/matchengine/server.rs
@@ -121,7 +121,10 @@ impl GrpcHandler {
     }
 
     pub fn on_leave(&mut self) -> ServerLeave {
-        ServerLeave(self.task_dispacther.clone(), self.set_close.take().expect("Do not call twice with on_leave"))
+        ServerLeave(
+            self.task_dispacther.clone(),
+            self.set_close.take().expect("Do not call twice with on_leave"),
+        )
     }
 }
 

--- a/src/message/consumer.rs
+++ b/src/message/consumer.rs
@@ -21,6 +21,21 @@ pub trait RdConsumerExt {
     fn to_self(&self) -> &Self::SelfType;
 }
 
+//implied for consumer types current we have known in rdkafka, for more types, implied
+//then with the new type idiom in your code
+impl<C: ConsumerContext + 'static> RdConsumerExt for stream_consumer::StreamConsumer<C> {
+    type CTXType = stream_consumer::StreamConsumerContext<C>;
+    type SelfType = stream_consumer::StreamConsumer<C>;
+    fn to_self(&self) -> &Self::SelfType {&self}    
+}
+
+impl<C: ConsumerContext> RdConsumerExt for base_consumer::BaseConsumer<C> {
+    type CTXType = C;
+    type SelfType = base_consumer::BaseConsumer<C>;
+    fn to_self(&self) -> &Self::SelfType {&self}    
+}
+
+
 /*
     Notice this trait is not easy to be implied (self cannot be involved
     into the return futures, that is why I abondoned the async_trait macro)

--- a/src/message/consumer.rs
+++ b/src/message/consumer.rs
@@ -82,7 +82,7 @@ impl<'c, C: RdConsumerExt> SimpleConsumer<'c, C> {
         Ok(self)
     }
 
-    pub fn add_topic_config<CF>(self, builder: CF) -> Result<SimpleConsumer<'c, C>> 
+    pub fn add_topic_config<'a, CF>(self, builder: &'a CF) -> Result<SimpleConsumer<'c, C>> 
     where 
         CF: TopicBuilder<C>,
     {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,5 +1,5 @@
 use crate::market::Order;
-use crate::types::{OrderEventType, SimpleResult, Trade};
+use crate::types::{OrderEventType, SimpleResult};
 use core::cell::RefCell;
 
 use anyhow::{anyhow, Result};
@@ -53,6 +53,9 @@ pub struct OrderMessage {
     pub base: String,
     pub quote: String,
 }
+
+//re-export from market, act as TradeMessage
+pub use crate::market::Trade;
 
 #[derive(Serialize, Deserialize)]
 pub struct MessageSenderStatus {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -44,9 +44,11 @@ pub struct BalanceMessage {
     pub asset: String,
     pub business: String,
     pub change: String,
+    pub balance: String,
+    pub detail: String,
 }
 
-#[derive(Debug, Serialize)] //, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)] //, Deserialize)]
 pub struct OrderMessage {
     pub event: OrderEventType,
     pub order: Order,

--- a/src/message/persist.rs
+++ b/src/message/persist.rs
@@ -36,8 +36,8 @@ where
     fn on_no_msg(&self, _cr: &'c C::SelfType) {} //do nothing
 }
 
-impl From<types::Trade> for models::TradeRecord {
-    fn from(origin: types::Trade) -> models::TradeRecord {
+impl From<super::Trade> for models::TradeRecord {
+    fn from(origin: super::Trade) -> models::TradeRecord {
         models::TradeRecord {
             time: utils::FTimestamp(origin.timestamp).into(),
             market: origin.market.clone(),

--- a/src/message/persist.rs
+++ b/src/message/persist.rs
@@ -1,4 +1,4 @@
-use super::consumer::{self, RdConsumerExt}; //crate::message::consumer
+use super::consumer::{self, RdConsumerExt, TypedMessageHandlerAsync, TypedMessageHandler, SyncTyped}; //crate::message::consumer
 use crate::{database, models, types, utils};
 use serde::Deserialize;
 use std::cell::RefCell;
@@ -14,30 +14,211 @@ pub struct MsgDataPersistor<U: Clone + Send, UM> {
 }
 
 impl<U: Clone + Send, UM> MsgDataPersistor<U, UM> {
-    pub fn new(src: &database::DatabaseWriter<U>) -> Self {
+    pub fn new(src: &database::DatabaseWriter<U>) -> SyncTyped<Self> {
+        SyncTyped::from(Self::new_raw(src))
+    }
+
+    fn new_raw(src: &database::DatabaseWriter<U>) -> Self {
         MsgDataPersistor::<U, UM> {
             writer: RefCell::new(src.get_entry().unwrap()),
             _phantom: PhantomData,
         }
-    }
+    }    
 }
 
 //An simple handler, just persist it by DatabaseWriter
-impl<'c, C, U, UM> consumer::TypedMessageHandler<'c, C> for MsgDataPersistor<U, UM>
+impl<'c, C, U, UM> TypedMessageHandler<'c, C> for MsgDataPersistor<U, UM>
 where
     UM: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
-    U: Clone + Send + Sync + From<UM>,
+    for<'r> &'r UM: Into<U>,
+    U: Clone + Send + Sync,
     C: RdConsumerExt + 'static,
 {
     type DataType = UM;
     fn on_message(&self, msg: UM, _cr: &'c C::SelfType) {
-        self.writer.borrow_mut().gen().append(From::from(msg)).ok();
+        self.writer.borrow_mut().gen().append(Into::into(&msg)).ok();
     }
     fn on_no_msg(&self, _cr: &'c C::SelfType) {} //do nothing
 }
 
-impl From<super::Trade> for models::TradeRecord {
-    fn from(origin: super::Trade) -> models::TradeRecord {
+//Try chainning handlers ...
+pub struct EmptyHandler<U> {
+    _phantom: PhantomData<U>,
+}
+
+impl<'c, C, UM> TypedMessageHandler<'c, C> for EmptyHandler<UM>
+where
+    C: RdConsumerExt + 'static,
+    UM: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
+{
+    type DataType = UM;
+    fn on_message(&self, _msg: UM, _cr: &'c C::SelfType) {}
+    fn on_no_msg(&self, _cr: &'c C::SelfType) {}
+}
+
+pub struct ChainedHandler<T1, T2> (T1, T2);
+
+impl<'c, C, U, UM, T> TypedMessageHandlerAsync<'c, C> for ChainedHandler<MsgDataPersistor<U, UM>, T> 
+where
+    C: RdConsumerExt + 'static,
+    UM: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
+    for<'r> &'r UM: Into<U>,
+    U: Clone + Send + Sync,
+    T: TypedMessageHandlerAsync<'c, C, DataType = UM> + 'static,
+{
+    type DataType = UM;
+    fn on_message(&self, msg: UM, cr: &'c C::SelfType) 
+        -> consumer::PinBox<dyn futures::Future<Output = ()> + Send>{
+        self.0.writer.borrow_mut().gen().append(Into::into(&msg)).ok();
+        self.1.on_message(msg, cr)
+    }
+    fn on_no_msg(&self, cr: &'c C::SelfType) -> consumer::PinBox<dyn futures::Future<Output = ()> + Send>
+    {self.1.on_no_msg(cr)}    
+}
+
+//Config builder ...
+pub trait TypedTopicConfig
+{
+//    type TypedHandlerType: for <'r> TypedMessageHandlerAsync<'r, C, DataType = Self::DataType> + for <'r> From<&'r Self> + 'static;
+    fn topic_name(&self) -> &str;
+}
+
+pub trait FromTopicConfig<T>
+{
+    fn from_config<'r, C: RdConsumerExt>(cfg : &'r T) -> Self;
+}
+
+pub trait TypedTopicHandlerData<C: RdConsumerExt> : Sized
+{
+    type DataType : 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync;
+    type HandlerType : for <'r> TypedMessageHandlerAsync<'r, C, DataType = Self::DataType> + FromTopicConfig<Self> + 'static;
+}
+
+pub struct TopicConfig<U> {
+    topic: String,
+    _phantom: PhantomData<U>,
+}
+
+impl<U> TypedTopicConfig for TopicConfig<U>
+{
+    fn topic_name(&self) -> &str {&self.topic}
+}
+
+impl<U> FromTopicConfig<TopicConfig<U>> for consumer::Synced<EmptyHandler<U>>
+where 
+    U: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
+{
+    fn from_config<'r, C: RdConsumerExt>(_origin : &'r TopicConfig<U>) -> Self
+    {
+        consumer::Synced::from(EmptyHandler{_phantom: PhantomData})
+    }
+}
+
+impl<C, U> TypedTopicHandlerData<C>  for TopicConfig<U>
+where 
+    C: RdConsumerExt + 'static,
+    U: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
+{
+    type DataType = U;
+    type HandlerType = consumer::Synced<EmptyHandler<U>>;
+}
+
+pub struct ChainedTopicBuilder<'a, T, NXC> 
+where 
+    T: Clone + Send + Sync,
+{
+    next_config: NXC,
+    dbwriter: &'a database::DatabaseWriter<T>,
+}
+
+impl<'a, T, NXC> TypedTopicConfig for ChainedTopicBuilder<'a, T, NXC>
+where 
+    T: Clone + Send + Sync,
+    NXC: TypedTopicConfig + 'a,
+{
+    fn topic_name(&self) -> &str {&self.next_config.topic_name()}
+}
+
+impl<'a, T, U, NXC, T1> FromTopicConfig<ChainedTopicBuilder<'a, T, NXC>> for ChainedHandler<MsgDataPersistor<T, U>, T1>
+where 
+    U: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
+    for<'x> &'x U: Into<T>,
+    T: Clone + Send + Sync,
+    T1: FromTopicConfig<NXC>,
+{
+    fn from_config<'r, C: RdConsumerExt>(origin : &'r ChainedTopicBuilder<'a, T, NXC>) -> Self
+    {
+        ChainedHandler(
+            MsgDataPersistor::new_raw(origin.dbwriter),
+            T1::from_config::<C>(&origin.next_config),
+        )
+    }
+}
+
+impl<'a, C, T, U, NXC> TypedTopicHandlerData<C> for ChainedTopicBuilder<'a, T, NXC>
+where 
+    C: RdConsumerExt + 'static,
+    MsgDataPersistor<T, U>: 'static,
+    U: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
+    for<'x> &'x U: Into<T>,
+    T: Clone + Send + Sync,
+    NXC: TypedTopicHandlerData<C, DataType = U>,
+{
+    type DataType = U;
+    type HandlerType = ChainedHandler<MsgDataPersistor<T, U>, NXC::HandlerType>;
+}
+
+impl<'a, C, T, U, NXC> consumer::TopicBuilder<C> for ChainedTopicBuilder<'a, T, NXC>
+where 
+    C: RdConsumerExt + 'static,
+    MsgDataPersistor<T, U>: 'static,
+    U: 'static + for<'de> Deserialize<'de> + std::fmt::Debug + Send + Sync,
+    for<'x> &'x U: Into<T>,
+    T: Clone + Send + Sync,
+    NXC: TypedTopicConfig + TypedTopicHandlerData<C, DataType = U> + 'a,
+{
+    type HandlerType = consumer::Typed<<Self as TypedTopicHandlerData<C>>::HandlerType>;
+    fn topic_name(&self) -> &str {<Self as TypedTopicConfig>::topic_name(&self)}
+    fn topic_handler(&self) -> Self::HandlerType{
+        consumer::Typed::from(<<Self as TypedTopicHandlerData<C>>::HandlerType>::from_config::<C>(&self))
+    }
+}
+
+impl<U> TopicConfig<U> 
+{
+    pub fn new(tpn :&str) -> Self
+    {
+        TopicConfig{
+            topic: tpn.to_string(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn persist_to<'a, T: Clone + Send + Sync>(self, db : &'a database::DatabaseWriter<T>) -> ChainedTopicBuilder<'a, T, Self>
+    {
+        ChainedTopicBuilder::<T, Self>{
+            next_config: self,
+            dbwriter: db,
+        }
+    }
+}
+
+impl<'a, T, NXC> ChainedTopicBuilder<'a, T, NXC> 
+where 
+    T: Clone + Send + Sync,
+    NXC: 'a,
+{
+    pub fn persist_to<'b : 'a, T1: Clone + Send + Sync>(self, db : &'b database::DatabaseWriter<T1>) -> ChainedTopicBuilder<'a, T1, Self>
+    {
+        ChainedTopicBuilder::<T1, Self>{
+            next_config: self,
+            dbwriter: db,
+        }
+    }
+}
+
+impl<'r> From<&'r super::Trade> for models::TradeRecord {
+    fn from(origin: &'r super::Trade) -> models::TradeRecord {
         models::TradeRecord {
             time: utils::FTimestamp(origin.timestamp).into(),
             market: origin.market.clone(),

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -135,6 +135,11 @@ pub type TaskNotifyFlag = HashMap<i32, u64>;
 pub struct TaskNotification(i32, u64);
 
 impl TaskNotification {
+
+    pub fn new<T1: Into<i32>, T2: Into<u64>>(v1: T1, v2: T2) -> Self{
+        TaskNotification(v1.into(), v2.into())
+    }
+
     fn add_to(self, target: &mut TaskNotifyFlag) {
         if let Some(old) = target.insert(self.0, self.1) {
             if old > self.1 {

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -70,6 +70,67 @@ impl ProgTracingStack {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    //the size of stack is limited: the maxium is just the
+    //uplimit of concurrent task, so we do not bother to
+    //use max/min heap
+    fn prepare_progtracking_stack() -> ProgTracingStack {
+
+        let mut ret = ProgTracingStack(Vec::new());
+
+        ret.push_top(1);
+        ret.push_top(3);
+        ret.push_top(5);
+        ret.push_top(4);
+        ret.push_top(2);
+
+        ret
+    }
+
+    #[test]
+    fn test_progtracking_stack_push() {
+
+        let case = prepare_progtracking_stack();
+
+        assert_eq!(case[0].0, 1);
+        assert_eq!(case[1].0, 2);
+        assert_eq!(case[2].0, 3);
+        assert_eq!(case[3].0, 4);
+        assert_eq!(case[4].0, 5);
+    }
+
+    #[test]
+    fn test_progtracking_stack_pop_1() {
+
+        let mut case = prepare_progtracking_stack();
+
+        assert_eq!(case.pop_top(1), Some(1));
+        assert_eq!(case.pop_top(4), None);
+        assert_eq!(case.pop_top(2), Some(2));
+        assert_eq!(case.pop_top(3), Some(4));
+        assert_eq!(case.pop_top(5), Some(5));
+        assert_eq!(case.is_empty(), true);
+    }
+
+    #[test]
+    fn test_progtracking_stack_pop_2() {
+
+        let mut case = prepare_progtracking_stack();
+
+        assert_eq!(case.pop_top(4), None);
+        assert_eq!(case.pop_top(2), None);
+        assert_eq!(case.pop_top(1), Some(2));
+        assert_eq!(case.pop_top(5), None);
+        assert_eq!(case.pop_top(3), Some(5));
+        assert_eq!(case.is_empty(), true);
+    }    
+}
+
 pub type TaskNotifyFlag = HashMap<i32, u64>;
 pub struct TaskNotification(i32, u64);
 

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -369,6 +369,10 @@ where
         self.sender.as_ref().map(|sd| DatabaseWriterEntry(sd.clone()))
     }
 
+    pub fn listen_notify(&self) -> sync::watch::Receiver<TaskNotifyFlag> {
+        self.complete_notify.clone()
+    }
+
     pub fn append(&mut self, item: U) -> Result<(), U> {
         self.append_with_notify(item, None)
     }

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -72,7 +72,7 @@ impl ProgTracingStack {
 
 
 #[cfg(test)]
-mod tests {
+mod tests_1 {
 
     use super::*;
 
@@ -145,6 +145,46 @@ impl TaskNotification {
     }
 }
 
+#[cfg(test)]
+mod tests_2 {
+
+    use super::*;
+
+    #[test]
+    fn test_tasknotification() {
+
+        let mut target : TaskNotifyFlag = HashMap::new();
+        let mut compare : TaskNotifyFlag = HashMap::new();
+        TaskNotification(1, 5).add_to(&mut target);
+        TaskNotification(2, 7).add_to(&mut target);
+        TaskNotification(1, 8).add_to(&mut target);
+
+        compare.insert(1, 8);
+        compare.insert(2, 7);
+        assert_eq!(target, compare);
+        compare.clear();
+
+        TaskNotification(3, 3).add_to(&mut target);
+        TaskNotification(3, 9).add_to(&mut target);
+        TaskNotification(2, 5).add_to(&mut target);
+        compare.insert(1, 8);
+        compare.insert(2, 7);
+        compare.insert(3, 9);
+        assert_eq!(target, compare);
+        compare.clear();
+
+        TaskNotification(3, 10).add_to(&mut target);
+        TaskNotification(1, 11).add_to(&mut target);
+        compare.insert(1, 11);
+        compare.insert(2, 7);
+        compare.insert(3, 10);
+        assert_eq!(target, compare);
+        compare.clear();
+
+    }  
+
+}
+
 struct ProgTracing(HashMap<i32, ProgTracingStack>);
 
 impl std::ops::Deref for ProgTracing {
@@ -181,6 +221,56 @@ impl ProgTracing {
             })
             .collect()
     }
+}
+
+
+#[cfg(test)]
+mod tests_3 {
+
+    use super::*;
+
+    #[test]
+    fn test_progtracing() {
+
+        let mut target = ProgTracing(HashMap::new());
+        let mut case1 : TaskNotifyFlag = HashMap::new();
+        
+        case1.insert(1, 2);
+        case1.insert(2, 1);
+        case1.insert(3, 3);
+        target.update_from(&case1);
+
+        let mut case2 : TaskNotifyFlag = HashMap::new();
+        case2.insert(1, 3);
+        case2.insert(3, 1);
+        target.update_from(&case2);
+        
+        let mut case3 : TaskNotifyFlag = HashMap::new();
+        case3.insert(1, 1);
+        case3.insert(2, 2);
+        case3.insert(3, 2);        
+        target.update_from(&case3);
+        
+        let out = target.finish_from(case2);
+        let mut compare : TaskNotifyFlag = HashMap::new();
+        compare.insert(3, 1);
+        assert_eq!(out, compare);
+
+        let out = target.finish_from(case3);
+        let mut compare : TaskNotifyFlag = HashMap::new();
+        compare.insert(1, 1);
+        compare.insert(3, 2);
+        assert_eq!(out, compare);
+
+        let out = target.finish_from(case1);
+        let mut compare : TaskNotifyFlag = HashMap::new();
+        compare.insert(1, 3);
+        compare.insert(2, 2);
+        compare.insert(3, 3);
+        assert_eq!(out, compare);
+
+    }  
+
 }
 
 struct DatabaseWriterTask<T> {
@@ -442,23 +532,30 @@ where
             self.status_notify.send(status_tracing.clone()).ok();
 
             tokio::select! {
-                Ok(conn) = self.pool.acquire(), if !error_task_stack.is_empty() => {
-                    tokio::spawn(error_task_stack.pop_back().unwrap().execute(conn, self.ctrl_notify.clone()));
-                }
-                Ok(conn) = self.pool.acquire(), if (
-                        !next_task_stack.is_empty() &&
-                        status_tracing.spawning_tasks < self.config.spawn_limit
-                )   => {
-                    status_tracing.spawning_tasks += 1;
-                    let mut task = next_task_stack.pop_back().unwrap();
-                    if self.config.apply_benchmark {
-                        task = task.apply_benchmark();
+                acquire_ret = self.pool.acquire(), if (!error_task_stack.is_empty()
+                    || (!next_task_stack.is_empty() &&
+                    status_tracing.spawning_tasks < self.config.spawn_limit)) => {
+                    match acquire_ret {
+                        Ok(conn) => {
+                            if !error_task_stack.is_empty() {
+                                tokio::spawn(error_task_stack.pop_back().unwrap().execute(conn, self.ctrl_notify.clone()));
+                            }else{
+                                status_tracing.spawning_tasks += 1;
+                                let mut task = next_task_stack.pop_back().unwrap();
+                                if self.config.apply_benchmark {
+                                    task = task.apply_benchmark();
+                                }
+                                status_tracing.pending_count -= task.data.len();
+                                if let Some(notifies) = task.notify_flag.as_ref(){
+                                    notify_tracing.update_from(notifies);
+                                }
+                                tokio::spawn(task.execute(conn, self.ctrl_notify.clone()));                                
+                            }
+                        },
+                        Err(err) => {
+                            log::error!("sql connection pool fail: {}", err);
+                        },
                     }
-                    status_tracing.pending_count -= task.data.len();
-                    if let Some(notifies) = task.notify_flag.as_ref(){
-                        notify_tracing.update_from(notifies);
-                    }
-                    tokio::spawn(task.execute(conn, self.ctrl_notify.clone()));
                 }
                 Some(msg) = self.ctrl_chn.recv() => {
                     match msg {
@@ -474,7 +571,6 @@ where
                             if let Some(notifies) = ctx.notify_flag.take() {
                                 self.complete_notify.send(notify_tracing.finish_from(notifies)).ok();
                             }
-                            if grace_down && status_tracing.spawning_tasks == 0 {break;}
                         },
                         WriterMsg::Fail(err, ctx) => {
                             log::error!("exec sql:  fail: {}. retry", err);
@@ -482,11 +578,18 @@ where
                         },
                         WriterMsg::Exit(grace) => {
                             grace_down = true;
-                            if !grace || status_tracing.spawning_tasks == 0 {
+                            if !grace {
                                 break;
                             }
                         },
                     }
+                }
+                _ = tokio::task::yield_now(), if (
+                    grace_down && 
+                    status_tracing.spawning_tasks == 0 &&
+                    next_task_stack.is_empty()
+                    ) => {
+                    break;
                 }
             }
         }

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -70,7 +70,6 @@ impl ProgTracingStack {
     }
 }
 
-
 #[cfg(test)]
 mod tests_1 {
 
@@ -80,7 +79,6 @@ mod tests_1 {
     //uplimit of concurrent task, so we do not bother to
     //use max/min heap
     fn prepare_progtracking_stack() -> ProgTracingStack {
-
         let mut ret = ProgTracingStack(Vec::new());
 
         ret.push_top(1);
@@ -94,7 +92,6 @@ mod tests_1 {
 
     #[test]
     fn test_progtracking_stack_push() {
-
         let case = prepare_progtracking_stack();
 
         assert_eq!(case[0].0, 1);
@@ -106,7 +103,6 @@ mod tests_1 {
 
     #[test]
     fn test_progtracking_stack_pop_1() {
-
         let mut case = prepare_progtracking_stack();
 
         assert_eq!(case.pop_top(1), Some(1));
@@ -119,7 +115,6 @@ mod tests_1 {
 
     #[test]
     fn test_progtracking_stack_pop_2() {
-
         let mut case = prepare_progtracking_stack();
 
         assert_eq!(case.pop_top(4), None);
@@ -128,15 +123,14 @@ mod tests_1 {
         assert_eq!(case.pop_top(5), None);
         assert_eq!(case.pop_top(3), Some(5));
         assert_eq!(case.is_empty(), true);
-    }    
+    }
 }
 
 pub type TaskNotifyFlag = HashMap<i32, u64>;
 pub struct TaskNotification(i32, u64);
 
 impl TaskNotification {
-
-    pub fn new<T1: Into<i32>, T2: Into<u64>>(v1: T1, v2: T2) -> Self{
+    pub fn new<T1: Into<i32>, T2: Into<u64>>(v1: T1, v2: T2) -> Self {
         TaskNotification(v1.into(), v2.into())
     }
 
@@ -157,9 +151,8 @@ mod tests_2 {
 
     #[test]
     fn test_tasknotification() {
-
-        let mut target : TaskNotifyFlag = HashMap::new();
-        let mut compare : TaskNotifyFlag = HashMap::new();
+        let mut target: TaskNotifyFlag = HashMap::new();
+        let mut compare: TaskNotifyFlag = HashMap::new();
         TaskNotification(1, 5).add_to(&mut target);
         TaskNotification(2, 7).add_to(&mut target);
         TaskNotification(1, 8).add_to(&mut target);
@@ -185,9 +178,7 @@ mod tests_2 {
         compare.insert(3, 10);
         assert_eq!(target, compare);
         compare.clear();
-
-    }  
-
+    }
 }
 
 struct ProgTracing(HashMap<i32, ProgTracingStack>);
@@ -228,7 +219,6 @@ impl ProgTracing {
     }
 }
 
-
 #[cfg(test)]
 mod tests_3 {
 
@@ -236,46 +226,43 @@ mod tests_3 {
 
     #[test]
     fn test_progtracing() {
-
         let mut target = ProgTracing(HashMap::new());
-        let mut case1 : TaskNotifyFlag = HashMap::new();
-        
+        let mut case1: TaskNotifyFlag = HashMap::new();
+
         case1.insert(1, 2);
         case1.insert(2, 1);
         case1.insert(3, 3);
         target.update_from(&case1);
 
-        let mut case2 : TaskNotifyFlag = HashMap::new();
+        let mut case2: TaskNotifyFlag = HashMap::new();
         case2.insert(1, 3);
         case2.insert(3, 1);
         target.update_from(&case2);
-        
-        let mut case3 : TaskNotifyFlag = HashMap::new();
+
+        let mut case3: TaskNotifyFlag = HashMap::new();
         case3.insert(1, 1);
         case3.insert(2, 2);
-        case3.insert(3, 2);        
+        case3.insert(3, 2);
         target.update_from(&case3);
-        
+
         let out = target.finish_from(case2);
-        let mut compare : TaskNotifyFlag = HashMap::new();
+        let mut compare: TaskNotifyFlag = HashMap::new();
         compare.insert(3, 1);
         assert_eq!(out, compare);
 
         let out = target.finish_from(case3);
-        let mut compare : TaskNotifyFlag = HashMap::new();
+        let mut compare: TaskNotifyFlag = HashMap::new();
         compare.insert(1, 1);
         compare.insert(3, 2);
         assert_eq!(out, compare);
 
         let out = target.finish_from(case1);
-        let mut compare : TaskNotifyFlag = HashMap::new();
+        let mut compare: TaskNotifyFlag = HashMap::new();
         compare.insert(1, 3);
         compare.insert(2, 2);
         compare.insert(3, 3);
         assert_eq!(out, compare);
-
-    }  
-
+    }
 }
 
 struct DatabaseWriterTask<T> {
@@ -554,7 +541,7 @@ where
                                 if let Some(notifies) = task.notify_flag.as_ref(){
                                     notify_tracing.update_from(notifies);
                                 }
-                                tokio::spawn(task.execute(conn, self.ctrl_notify.clone()));                                
+                                tokio::spawn(task.execute(conn, self.ctrl_notify.clone()));
                             }
                         },
                         Err(err) => {
@@ -590,7 +577,7 @@ where
                     }
                 }
                 _ = tokio::task::yield_now(), if (
-                    grace_down && 
+                    grace_down &&
                     status_tracing.spawning_tasks == 0 &&
                     next_task_stack.is_empty()
                     ) => {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -32,28 +32,6 @@ pub enum OrderType {
     MARKET,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Trade {
-    pub id: u64,
-    pub timestamp: f64, // unix epoch timestamp,
-    pub market: String,
-    pub base: String,
-    pub quote: String,
-    pub price: rust_decimal::Decimal,
-    pub amount: rust_decimal::Decimal,
-    pub quote_amount: rust_decimal::Decimal,
-
-    pub ask_user_id: u32,
-    pub ask_order_id: u64,
-    pub ask_role: MarketRole, // take/make
-    pub ask_fee: rust_decimal::Decimal,
-
-    pub bid_user_id: u32,
-    pub bid_order_id: u64,
-    pub bid_role: MarketRole,
-    pub bid_fee: rust_decimal::Decimal,
-}
-
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub enum OrderEventType {
     PUT = 1,


### PR DESCRIPTION
Here is an extending from kline: a daemon (bin/persistor) which consuming all topics from matchengine, and persist them into history db, so matchengine can has less burden on persisting.

This work include following features:

1. Enable matchengine use different persist policy for history data: persist them by matchegine itself, also output the data to kafka (current, and default policy), only output to kafka or only persisting.
2. A fully function persisting implement for consumed message. Now it enable user to bind multiple persisting task on a single topic
3. A auto-commit feature to ensue no data will be missed: daemon commit a kafka message only after it does persist it. For the case multiple persisting is binded. A message will be commited after ALL the persisting task has completed.
