### PR TITLE
Fully support UDF for Charting Library

### DIFF
--- a/migrations/20210310150412_market_constraint.sql
+++ b/migrations/20210310150412_market_constraint.sql
@@ -1,0 +1,4 @@
+-- Add migration script here
+
+CREATE UNIQUE INDEX market_name_constraint ON market (market_name) WHERE market_name IS NOT NULL;
+CREATE UNIQUE INDEX market_pair_constraint_when_null ON market (base_asset, quote_asset) WHERE market_name IS NULL;

--- a/src/bin/restapi.rs
+++ b/src/bin/restapi.rs
@@ -18,7 +18,7 @@ use restapi::manage::market;
 use restapi::personal_history::my_orders;
 use restapi::public_history::{order_trades, recent_trades};
 use restapi::state::{AppCache, AppState};
-use restapi::tradingview::{chart_config, history, symbols, ticker, unix_timestamp};
+use restapi::tradingview::{chart_config, history, search_symbols, symbols, ticker, unix_timestamp};
 use restapi::types::UserInfo;
 
 async fn ping(_req: HttpRequest, _data: web::Data<AppState>) -> impl Responder {
@@ -91,6 +91,7 @@ async fn main() -> std::io::Result<()> {
                     web::scope("/tradingview")
                         .route("/time", web::get().to(unix_timestamp))
                         .route("/config", web::get().to(chart_config))
+                        .route("/search", web::get().to(search_symbols))
                         .route("/symbols", web::get().to(symbols))
                         .route("/history", web::get().to(history)),
                 )

--- a/src/restapi/errors.rs
+++ b/src/restapi/errors.rs
@@ -64,10 +64,8 @@ impl From<QueryPayloadError> for RpcError {
 impl From<sqlx::Error> for RpcError {
     fn from(original: sqlx::Error) -> RpcError {
         match original {
-            sqlx::error::Error::RowNotFound => 
-                RpcError::new(ErrorType::NotFound, "db query nothing".to_string()),
-            sqlx::error::Error::Database(e) =>
-                RpcError::bad_request(&e.to_string()),
+            sqlx::error::Error::RowNotFound => RpcError::new(ErrorType::NotFound, "db query nothing".to_string()),
+            sqlx::error::Error::Database(e) => RpcError::bad_request(&e.to_string()),
             _ => RpcError::unknown(&original.to_string()),
         }
     }

--- a/src/restapi/errors.rs
+++ b/src/restapi/errors.rs
@@ -63,6 +63,12 @@ impl From<QueryPayloadError> for RpcError {
 
 impl From<sqlx::Error> for RpcError {
     fn from(original: sqlx::Error) -> RpcError {
-        RpcError::unknown(&original.to_string())
+        match original {
+            sqlx::error::Error::RowNotFound => 
+                RpcError::new(ErrorType::NotFound, "db query nothing".to_string()),
+            sqlx::error::Error::Database(e) =>
+                RpcError::bad_request(&e.to_string()),
+            _ => RpcError::unknown(&original.to_string()),
+        }
     }
 }

--- a/src/restapi/public_history.rs
+++ b/src/restapi/public_history.rs
@@ -34,6 +34,7 @@ pub async fn recent_trades(req: HttpRequest, data: web::Data<AppState>) -> impl 
     let sql_query = format!("select * from {} where market = $1 order by time desc limit {}", MARKETTRADE, limit);
 
     let trades: Vec<models::MarketTrade> = sqlx::query_as(&sql_query).bind(market).fetch_all(&data.db).await?;
+    log::debug!("query {} recent_trades records", trades.len());
 
     Ok(Json(trades))
 }

--- a/src/restapi/tradingview.rs
+++ b/src/restapi/tradingview.rs
@@ -13,7 +13,10 @@ use crate::restapi::state;
 
 use super::mock;
 
-use crate::models::{MarketDesc, tablenames::{MARKET, MARKETTRADE}};
+use crate::models::{
+    tablenames::{MARKET, MARKETTRADE},
+    MarketDesc,
+};
 
 // All APIs here follow https://zlq4863947.gitbook.io/tradingview/3-shu-ju-bang-ding/udf
 
@@ -21,11 +24,12 @@ pub async fn unix_timestamp(_req: HttpRequest) -> impl Responder {
     format!("{}", SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs())
 }
 
-static DEFAULT_EXCHANGE : &str = "test";
-static DEFAULT_SYMBOL : &str = "tradepair";
-static DEFAULT_SESSION : &str = "24x7";
+static DEFAULT_EXCHANGE: &str = "test";
+static DEFAULT_SYMBOL: &str = "tradepair";
+static DEFAULT_SESSION: &str = "24x7";
 
 pub async fn chart_config(_req: HttpRequest) -> impl Responder {
+    log::debug!("request config");
     let value = json!({
         "supports_search": true,
         "supports_group_request": false,
@@ -48,7 +52,7 @@ pub async fn chart_config(_req: HttpRequest) -> impl Responder {
 
 #[derive(Deserialize)]
 pub struct SymbolQueryReq {
-   symbol: String,
+    symbol: String,
 }
 
 #[derive(Serialize)]
@@ -56,61 +60,80 @@ pub struct Symbol {
     name: String,
     ticker: String,
     #[serde(rename = "type")]
-   sym_type: String,
-   session: String,
-   exchange: String,
-   listed_exchange: String,
-   //TODO: we can use a enum
-   timezone: String,
-   minmov: u32,
-   pricescale: u32,
-   //TODO: this two field may has been deprecated
-   minmovement2: u32,
-   minmov2: u32,
-   #[serde(skip_serializing_if = "Option::is_none")]
-   minmove2: Option<u32>,
-   #[serde(skip_serializing_if = "Option::is_none")]
-   fractional: Option<bool>,
-   has_intraday: bool,
-   has_daily: bool,
-   has_weekly_and_monthly: bool,
+    sym_type: String,
+    session: String,
+    exchange: String,
+    listed_exchange: String,
+    //TODO: we can use a enum
+    timezone: String,
+    minmov: u32,
+    pricescale: u32,
+    //TODO: this two field may has been deprecated
+    minmovement2: u32,
+    minmov2: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minmove2: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fractional: Option<bool>,
+    has_intraday: bool,
+    has_daily: bool,
+    has_weekly_and_monthly: bool,
 }
 
 impl Default for Symbol {
     fn default() -> Self {
         Symbol {
-           name: String::default(),
-           ticker: String::default(),
-           sym_type: DEFAULT_SYMBOL.to_string(),
-           session: DEFAULT_SESSION.to_string(),
-           exchange: DEFAULT_EXCHANGE.to_string(),
-           listed_exchange: DEFAULT_EXCHANGE.to_string(),
-           timezone: "Etc/UTC".to_string(),
-           minmov: 1,
-           pricescale: 100,
-           minmovement2: 0,
-           minmov2: 0,
-           minmove2: None,
-           fractional: None,
-           has_intraday: true,
-           has_daily: true,
-           has_weekly_and_monthly: true,
-        }        
+            name: String::default(),
+            ticker: String::default(),
+            sym_type: DEFAULT_SYMBOL.to_string(),
+            session: DEFAULT_SESSION.to_string(),
+            exchange: DEFAULT_EXCHANGE.to_string(),
+            listed_exchange: DEFAULT_EXCHANGE.to_string(),
+            timezone: "Etc/UTC".to_string(),
+            minmov: 1,
+            pricescale: 100,
+            minmovement2: 0,
+            minmov2: 0,
+            minmove2: None,
+            fractional: None,
+            has_intraday: true,
+            has_daily: true,
+            has_weekly_and_monthly: true,
+        }
     }
 }
 
-impl From<MarketDesc> for Symbol {
-    fn from(origin : MarketDesc) -> Self {
-        let s_name = format!("{}_{}", origin.base_asset, origin.quote_asset);
-        let ticker = origin.market_name.unwrap_or(s_name.clone());
+type SymNameAndTicker = String;
+type FullName = String;
 
+/*
+   According to the symbology of chart [https://github.com/serdimoa/charting/blob/master/Symbology.md],
+   it may refer a symbol by EXCHANGE:SYMBOL format, to made things easy, our symbology always specify
+   a ticker which is identify with symbol name itself, which is the market_name used in matchingengine
+   and db record ({base asset}_{quote asset} or an specified name), to keep all API running correct,
+   and the user of chart libaray can use symbol() method to acquire current symbol name for their API
+*/
+fn symbology(origin: &MarketDesc) -> (SymNameAndTicker, FullName) {
+    let s_name = format!("{}_{}", origin.base_asset, origin.quote_asset);
+    (
+        origin.market_name.clone().unwrap_or_else(|| s_name.clone()),
+        origin
+            .market_name
+            .clone()
+            .map_or_else(|| s_name.clone(), |n| format!("{}({})", n, s_name)),
+    )
+}
+
+impl From<MarketDesc> for Symbol {
+    fn from(origin: MarketDesc) -> Self {
+        let (name, _) = symbology(&origin);
         let pricescale = 10u32.pow(origin.min_amount.scale());
-        //simply pick the lo part 
+        //simply pick the lo part
         let minmov = origin.min_amount.unpack().lo;
 
         Symbol {
-            name: s_name,
-            ticker: ticker,
+            name: name.clone(),
+            ticker: name,
             sym_type: DEFAULT_SYMBOL.to_string(),
             session: DEFAULT_SESSION.to_string(),
             exchange: DEFAULT_EXCHANGE.to_string(),
@@ -130,30 +153,33 @@ impl From<MarketDesc> for Symbol {
 }
 
 #[cfg(sqlxverf)]
-fn sqlverf_symbol_search() -> impl std::any::Any {
-    (sqlx::query_as!(
-        MarketDesc,
-        "select * from market where base_asset = $1 AND quote_asset = $2",
-        "UNI", "ETH"),
-    sqlx::query_as!(
-        MarketDesc,
-        "select * from market where market_name = $1",
-        "Any spec name"),                
+fn sqlverf_symbol_resolve() -> impl std::any::Any {
+    (
+        sqlx::query_as!(
+            MarketDesc,
+            "select * from market where 
+        (base_asset = $1 AND quote_asset = $2) OR
+        (base_asset = $2 AND quote_asset = $1)",
+            "UNI",
+            "ETH"
+        ),
+        sqlx::query_as!(MarketDesc, "select * from market where market_name = $1", "Any spec name"),
     )
 }
 
-pub async fn symbols(symbol_req: web::Query<SymbolQueryReq>, 
-    app_state: Data<state::AppState>) -> Result<web::Json<Symbol>, RpcError> {
+pub async fn symbols(symbol_req: web::Query<SymbolQueryReq>, app_state: Data<state::AppState>) -> Result<web::Json<Symbol>, RpcError> {
     let symbol = symbol_req.into_inner().symbol;
-    log::debug!("kline get symbol {:?}", symbol);
+    log::debug!("resolve symbol {:?}", symbol);
 
-    let as_asset : Vec<&str> = symbol.split(&[':','_'][..]).collect();
-    let mut queried_market : Option<MarketDesc> = None;
+    let as_asset: Vec<&str> = symbol.split(&[':', '_'][..]).collect();
+    let mut queried_market: Option<MarketDesc> = None;
     //try asset first
     if as_asset.len() == 2 {
         log::debug!("query market from asset {}:{}", as_asset[0], as_asset[1]);
         let symbol_query_1 = format!(
-            "select * from {} where base_asset = $1 AND quote_asset = $2",
+            "select * from {} where 
+            (base_asset = $1 AND quote_asset = $2) OR
+            (base_asset = $2 AND quote_asset = $1)",
             MARKET
         );
         queried_market = sqlx::query_as(&symbol_query_1)
@@ -165,22 +191,16 @@ pub async fn symbols(symbol_req: web::Query<SymbolQueryReq>,
 
     let queried_market = if queried_market.is_none() {
         log::debug!("query market from name {}", symbol);
-        let symbol_query_2 = format!(
-            "select * from {} where market_name = $1",
-            MARKET
-        );
+        let symbol_query_2 = format!("select * from {} where market_name = $1", MARKET);
         //TODO: would this returning correct? should we just
         //response 404?
-        sqlx::query_as(&symbol_query_2)
-            .bind(&symbol)
-            .fetch_one(&app_state.db)
-            .await?
-    }else{
+        sqlx::query_as(&symbol_query_2).bind(&symbol).fetch_one(&app_state.db).await?
+    } else {
         queried_market.unwrap()
     };
 
     Ok(Json(Symbol::from(queried_market)))
-/*    Ok(json!(
+    /*    Ok(json!(
         {
             "name": "ETH_USDT",
             "ticker": "ETH_USDT",
@@ -201,6 +221,95 @@ pub async fn symbols(symbol_req: web::Query<SymbolQueryReq>,
         }
     )
     .to_string())*/
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SymbolSearchQueryReq {
+    query: String,
+    #[serde(default, rename = "type")]
+    sym_type: Option<String>,
+    #[serde(default)]
+    exchange: Option<String>,
+    #[serde(default)]
+    limit: u32,
+}
+
+#[derive(Serialize)]
+pub struct SymbolDesc {
+    symbol: String,
+    full_name: String, // e.g. BTCE:BTCUSD
+    description: String,
+    exchange: String,
+    ticker: String,
+    #[serde(rename = "type")]
+    sym_type: String,
+}
+
+impl From<MarketDesc> for SymbolDesc {
+    fn from(origin: MarketDesc) -> Self {
+        let (name, full_name) = symbology(&origin);
+
+        SymbolDesc {
+            symbol: name.clone(),
+            full_name: format!("{}:{}", DEFAULT_EXCHANGE, full_name),
+            description: String::default(),
+            sym_type: DEFAULT_SYMBOL.to_string(),
+            ticker: name,
+            exchange: DEFAULT_EXCHANGE.to_string(),
+        }
+    }
+}
+
+#[cfg(sqlxverf)]
+fn sqlverf_symbol_search() -> impl std::any::Any {
+    sqlx::query_as!(
+        MarketDesc,
+        "select * from market where base_asset = $1 OR quote_asset = $1 OR market_name = $1",
+        "UNI"
+    )
+}
+
+pub async fn search_symbols(
+    symbol_search_req: web::Query<SymbolSearchQueryReq>,
+    app_state: Data<state::AppState>,
+) -> Result<web::Json<Vec<SymbolDesc>>, RpcError> {
+    let symbol_query = symbol_search_req.into_inner();
+    log::debug!("search symbol {:?}", symbol_query);
+
+    let as_asset: Vec<&str> = symbol_query.query.split(&[':', '_'][..]).collect();
+    let limit_query = if symbol_query.limit == 0 {
+        "".to_string()
+    } else {
+        format!(" limit {}", symbol_query.limit)
+    };
+    //use different query type
+    //try asset first
+
+    let ret: Vec<MarketDesc> = if as_asset.len() == 2 {
+        log::debug!("query symbol as trade pair {}:{}", as_asset[0], as_asset[1]);
+        let symbol_query_1 = format!(
+            "select * from {} where (base_asset = $1 AND quote_asset = $2) OR
+            (base_asset = $2 AND quote_asset = $1){}",
+            MARKET, limit_query
+        );
+        sqlx::query_as(&symbol_query_1)
+            .bind(as_asset[0])
+            .bind(as_asset[1])
+            .fetch_all(&app_state.db)
+            .await?
+    } else {
+        log::debug!("query symbol as name {}", symbol_query.query);
+        let symbol_query_2 = format!(
+            "select * from {} where base_asset = $1 OR quote_asset = $1 OR market_name = $1{}",
+            MARKET, limit_query
+        );
+        sqlx::query_as(&symbol_query_2)
+            .bind(&symbol_query.query)
+            .fetch_all(&app_state.db)
+            .await?
+    };
+
+    Ok(Json(ret.into_iter().map(From::from).collect()))
 }
 
 use chrono::{self, DurationRound};


### PR DESCRIPTION
This also fix #93. restapi now response the calling from charting library with market configurations stored in db.

+ symbol resolve API (/symbos) has been fully supported, it also correct the pair in resolving. i.e.: if we have a market "UNI_USDT" and someone try to resolved "USDT_UNI", it would be resolved to the corresponding market (UNI_USDT) successfully.

+ symbol search has been supported, which is required according to the config. Frontend can search symbols if we had enabled the charting feature.