### PR TITLE
Feature: order messages

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -56,4 +56,4 @@ services:
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
-      KAFKA_CREATE_TOPICS: "trades:1:1,orders:1:1,balances:1:1"
+      KAFKA_CREATE_TOPICS: "trades:1:1,orders:1:1,balances:1:1,unifyevents:1:1"

--- a/src/bin/test_unifymessenger.rs
+++ b/src/bin/test_unifymessenger.rs
@@ -9,29 +9,29 @@ use std::io::Write;
 use std::sync::Mutex;
 
 use dingir_exchange::{config, message};
-use message::consumer::{SimpleConsumer, SimpleMessageHandler, Simple};
+use message::consumer::{Simple, SimpleConsumer, SimpleMessageHandler};
 
 use rdkafka::consumer::StreamConsumer;
-use rdkafka::message::{Message, BorrowedMessage};
+use rdkafka::message::{BorrowedMessage, Message};
 
 struct MessageWriter {
     out_file: Mutex<File>,
 }
 
 impl SimpleMessageHandler for &MessageWriter {
-    fn on_message(&self, msg: &BorrowedMessage<'_>){
-
+    fn on_message(&self, msg: &BorrowedMessage<'_>) {
         let mut file = self.out_file.lock().unwrap();
 
         let msgtype = match std::str::from_utf8(msg.key().unwrap()).unwrap() {
             "orders" => "OrderMessage",
             "trades" => "TradeMessage",
             "balances" => "BalanceMessage",
-            _ => unreachable!(),  
+            _ => unreachable!(),
         };
 
         let payloadmsg = std::str::from_utf8(msg.payload().unwrap()).unwrap();
-        file.write_fmt(format_args!("{{\"type\":\"{}\",\"value\":{}}}\n", msgtype, payloadmsg)).unwrap();
+        file.write_fmt(format_args!("{{\"type\":\"{}\",\"value\":{}}}\n", msgtype, payloadmsg))
+            .unwrap();
     }
 }
 
@@ -69,8 +69,8 @@ fn main() {
 
         loop {
             let cr_main = SimpleConsumer::new(consumer.as_ref())
-                .add_topic(message::UNIFY_TOPIC, Simple::from(&writer)).unwrap()
-            ;
+                .add_topic(message::UNIFY_TOPIC, Simple::from(&writer))
+                .unwrap();
 
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {

--- a/src/bin/test_unifymessenger.rs
+++ b/src/bin/test_unifymessenger.rs
@@ -1,0 +1,87 @@
+#![allow(dead_code)]
+#![allow(clippy::collapsible_if)]
+#![allow(clippy::let_and_return)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::single_char_pattern)]
+
+use std::fs::File;
+use std::io::Write;
+use std::sync::Mutex;
+
+use dingir_exchange::{config, message};
+use message::consumer::{SimpleConsumer, SimpleMessageHandler, Simple};
+
+use rdkafka::consumer::StreamConsumer;
+use rdkafka::message::{Message, BorrowedMessage};
+
+struct MessageWriter {
+    out_file: Mutex<File>,
+}
+
+impl SimpleMessageHandler for &MessageWriter {
+    fn on_message(&self, msg: &BorrowedMessage<'_>){
+
+        let mut file = self.out_file.lock().unwrap();
+
+        let msgtype = match std::str::from_utf8(msg.key().unwrap()).unwrap() {
+            "orders" => "OrderMessage",
+            "trades" => "TradeMessage",
+            "balances" => "BalanceMessage",
+            _ => unreachable!(),  
+        };
+
+        let payloadmsg = std::str::from_utf8(msg.payload().unwrap()).unwrap();
+        file.write_fmt(format_args!("{{\"type\":\"{}\",\"value\":{}}}\n", msgtype, payloadmsg)).unwrap();
+    }
+}
+
+fn main() {
+    dotenv::dotenv().ok();
+    env_logger::init();
+
+    let mut conf = config_rs::Config::new();
+    let config_file = dotenv::var("CONFIG_FILE").unwrap();
+    conf.merge(config_rs::File::with_name(&config_file)).unwrap();
+    let settings: config::Settings = conf.try_into().unwrap();
+    log::debug!("Settings: {:?}", settings);
+
+    let rt: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+
+    let writer = MessageWriter {
+        out_file: Mutex::new(File::create("output.txt").unwrap()),
+    };
+
+    rt.block_on(async move {
+        let consumer: StreamConsumer = rdkafka::config::ClientConfig::new()
+            .set("bootstrap.servers", &settings.brokers)
+            .set("group.id", &settings.consumer_group)
+            .set("enable.partition.eof", "false")
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", "true")
+            .set("auto.offset.reset", "earliest")
+            .create()
+            .unwrap();
+
+        let consumer = std::sync::Arc::new(consumer);
+
+        loop {
+            let cr_main = SimpleConsumer::new(consumer.as_ref())
+                .add_topic(message::UNIFY_TOPIC, Simple::from(&writer)).unwrap()
+            ;
+
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    log::info!("Ctrl-c received, shutting down");
+                    break;
+                },
+
+                err = cr_main.run_stream(|cr|cr.stream()) => {
+                    log::error!("Kafka consumer error: {}", err);
+                }
+            }
+        }
+    })
+}

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -4,7 +4,7 @@ use crate::database::{DatabaseWriterConfig, OperationLogSender};
 use crate::dto::*;
 use crate::history::{DatabaseHistoryWriter, HistoryWriter};
 use crate::market;
-use crate::message::{new_message_manager_with_kafka_backend, ChannelMessageManager, MessageManager};
+use crate::message::{new_message_manager_with_kafka_backend, MessageManager, ChannelMessageManager};
 use crate::models::{self};
 use crate::sequencer::Sequencer;
 use crate::storage::config::MarketConfigs;

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -4,7 +4,7 @@ use crate::database::{DatabaseWriterConfig, OperationLogSender};
 use crate::dto::*;
 use crate::history::{DatabaseHistoryWriter, HistoryWriter};
 use crate::market;
-use crate::message::{new_message_manager_with_kafka_backend, MessageManager, UnifyMessageManager, ChannelMessageManager};
+use crate::message::{new_message_manager_with_kafka_backend, ChannelMessageManager, MessageManager, UnifyMessageManager};
 use crate::models::{self};
 use crate::sequencer::Sequencer;
 use crate::storage::config::MarketConfigs;
@@ -84,7 +84,9 @@ impl DefaultPersistor {
 }
 
 pub trait IntoPersistor {
-    fn service_available(&self) -> bool {true}
+    fn service_available(&self) -> bool {
+        true
+    }
     fn persistor_for_market<'c>(&'c mut self, real: bool, market_tag: (String, String)) -> Box<dyn market::PersistExector + 'c>;
     fn persistor_for_balance<'c>(&'c mut self, real: bool) -> Box<dyn asset::PersistExector + 'c>;
 }
@@ -106,17 +108,12 @@ impl IntoPersistor for UnifyMessageManager {
         !self.is_block()
     }
     fn persistor_for_market<'c>(&'c mut self, _real: bool, market_tag: (String, String)) -> Box<dyn market::PersistExector + 'c> {
-        Box::new(market::persistor_for_message(
-            self,
-            market_tag,
-        ))
+        Box::new(market::persistor_for_message(self, market_tag))
     }
     fn persistor_for_balance<'c>(&'c mut self, _real: bool) -> Box<dyn asset::PersistExector + 'c> {
         Box::new(asset::persistor_for_message(self))
     }
 }
-
-
 
 pub trait OperationLogConsumer {
     fn is_block(&self) -> bool;

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -83,26 +83,24 @@ impl DefaultPersistor {
     }
 }
 
-trait Persistor {
-    fn service_available(&self) -> bool;
-    fn persistor_for_market(&mut self, real: bool, market_tag: (String, String)) -> Box<dyn market::PersistExector>;
-    fn persistor_for_balance(&mut self, real: bool) -> Box<dyn asset::PersistExector>;
+pub trait IntoPersistor {
+    fn service_available(&self) -> bool {true}
+    fn persistor_for_market<'c>(&'c mut self, real: bool, market_tag: (String, String)) -> Box<dyn market::PersistExector + 'c>;
+    fn persistor_for_balance<'c>(&'c mut self, real: bool) -> Box<dyn asset::PersistExector + 'c>;
 }
 
-/*
-// i failed to do this...
-impl<'a> Persistor for DefaultPersistor<'a> {
+impl IntoPersistor for DefaultPersistor {
     fn service_available(&self) -> bool {
         self.service_available()
     }
-    fn persistor_for_market(&mut self, real: bool, market_tag: (String, String)) -> Box<dyn market::PersistExector + 'a> {
+    fn persistor_for_market<'c>(&'c mut self, real: bool, market_tag: (String, String)) -> Box<dyn market::PersistExector + 'c> {
         self.is_real(real).persist_for_market(market_tag)
     }
-    fn persistor_for_balance(&mut self, real: bool) -> Box<dyn asset::PersistExector + 'a> {
+    fn persistor_for_balance<'c>(&'c mut self, real: bool) -> Box<dyn asset::PersistExector + 'c> {
         self.is_real(real).persist_for_balance()
     }
 }
-*/
+
 
 pub trait OperationLogConsumer {
     fn is_block(&self) -> bool;

--- a/src/matchengine/controller.rs
+++ b/src/matchengine/controller.rs
@@ -4,7 +4,7 @@ use crate::database::{DatabaseWriterConfig, OperationLogSender};
 use crate::dto::*;
 use crate::history::{DatabaseHistoryWriter, HistoryWriter};
 use crate::market;
-use crate::message::{new_message_manager_with_kafka_backend, MessageManager, ChannelMessageManager};
+use crate::message::{new_message_manager_with_kafka_backend, MessageManager, UnifyMessageManager, ChannelMessageManager};
 use crate::models::{self};
 use crate::sequencer::Sequencer;
 use crate::storage::config::MarketConfigs;
@@ -100,6 +100,22 @@ impl IntoPersistor for DefaultPersistor {
         self.is_real(real).persist_for_balance()
     }
 }
+
+impl IntoPersistor for UnifyMessageManager {
+    fn service_available(&self) -> bool {
+        !self.is_block()
+    }
+    fn persistor_for_market<'c>(&'c mut self, _real: bool, market_tag: (String, String)) -> Box<dyn market::PersistExector + 'c> {
+        Box::new(market::persistor_for_message(
+            self,
+            market_tag,
+        ))
+    }
+    fn persistor_for_balance<'c>(&'c mut self, _real: bool) -> Box<dyn asset::PersistExector + 'c> {
+        Box::new(asset::persistor_for_message(self))
+    }
+}
+
 
 
 pub trait OperationLogConsumer {

--- a/src/matchengine/market.rs
+++ b/src/matchengine/market.rs
@@ -1016,8 +1016,14 @@ mod tests {
                 maker_fee: dec!(0),
                 market: market.name.to_string(),
             };
-            market.put_order(sequencer, balance_manager.into(), 
-                persistor.persistor_for_market(true, (market.base.clone(), market.quote.clone())), order).unwrap();
+            market
+                .put_order(
+                    sequencer,
+                    balance_manager.into(),
+                    persistor.persistor_for_market(true, (market.base.clone(), market.quote.clone())),
+                    order,
+                )
+                .unwrap();
         }
     }
 

--- a/src/matchengine/market.rs
+++ b/src/matchengine/market.rs
@@ -258,6 +258,7 @@ impl DummyPersistor {
         Self { real_persist }
     }
 }
+/*
 impl PersistExector for &mut DummyPersistor {
     fn real_persist(&self) -> bool {
         self.real_persist
@@ -265,6 +266,7 @@ impl PersistExector for &mut DummyPersistor {
     fn put_order(&mut self, _order: &Order, _as_step: OrderEventType) {}
     fn put_trade(&mut self, _trade: &Trade) {}
 }
+*/
 impl PersistExector for DummyPersistor {
     fn real_persist(&self) -> bool {
         self.real_persist

--- a/src/matchengine/mock.rs
+++ b/src/matchengine/mock.rs
@@ -1,10 +1,13 @@
 use crate::asset::{self, AssetManager, BalanceManager};
 use crate::config;
 use crate::matchengine::{controller, market};
-use crate::message::{self, Message};
+use crate::message::{self, Message, UnifyMessageManager};
 use crate::models::BalanceHistory;
 use crate::types::OrderEventType;
 use rust_decimal_macros::*;
+
+use std::fs::File;
+use std::io::Write;
 
 pub fn get_simple_market_config() -> config::Market {
     config::Market {
@@ -53,6 +56,13 @@ pub fn get_simple_balance_manager(assets: Vec<config::Asset>) -> BalanceManager 
     BalanceManager::new(&assets).unwrap()
 }
 
+pub fn get_mocking_persistor() -> Box<dyn controller::IntoPersistor> {
+    match std::env::var("KAFKA_BROKER") {
+        Ok(val) => Box::new(UnifyMessageManager::new_and_run(&val).unwrap()),
+        Err(_) => Box::new(MockPersistor::new())
+    }
+}
+
 pub(super) struct MockPersistor {
     //orders: Vec<market::Order>,
     //trades: Vec<market::Trade>,
@@ -60,6 +70,7 @@ pub(super) struct MockPersistor {
 }
 impl MockPersistor {
     pub(super) fn new() -> Self {
+
         Self {
             //orders: Vec::new(),
             //trades: Vec::new(),
@@ -71,6 +82,19 @@ impl MockPersistor {
 fn get_market_base_and_quote(market: &str) -> (String, String) {
     let splits: Vec<&str> = market.split("_").collect();
     (splits[0].to_owned(), splits[1].to_owned())
+}
+
+impl Drop for MockPersistor{
+    fn drop(&mut self) {
+        let output_file_name = "output.txt";
+        let mut file = File::create(output_file_name).unwrap();
+        for item in self.messages.iter() {
+            let s = serde_json::to_string(item).unwrap();
+            file.write_fmt(format_args!("{}\n", s)).unwrap();
+        }
+        log::info!("output done")
+        //rust file need not to be closed manually
+    }    
 }
 
 impl market::PersistExector for &mut MockPersistor {

--- a/src/matchengine/mock.rs
+++ b/src/matchengine/mock.rs
@@ -1,6 +1,6 @@
 use crate::asset::{self, AssetManager, BalanceManager};
 use crate::config;
-use crate::matchengine::market;
+use crate::matchengine::{controller, market};
 use crate::message::{self, Message};
 use crate::models::BalanceHistory;
 use crate::types::OrderEventType;
@@ -100,5 +100,14 @@ impl asset::PersistExector for &mut MockPersistor {
             balance: balance.balance.to_string(),
             detail: balance.detail,
         })))
+    }
+}
+
+impl controller::IntoPersistor for MockPersistor {
+    fn persistor_for_market<'c>(&'c mut self, _real: bool, _market_tag: (String, String)) -> Box<dyn market::PersistExector + 'c> {
+        Box::new(self)
+    }
+    fn persistor_for_balance<'c>(&'c mut self, _real: bool) -> Box<dyn asset::PersistExector + 'c> {
+        Box::new(self)
     }
 }

--- a/src/matchengine/mock.rs
+++ b/src/matchengine/mock.rs
@@ -59,7 +59,7 @@ pub fn get_simple_balance_manager(assets: Vec<config::Asset>) -> BalanceManager 
 pub fn get_mocking_persistor() -> Box<dyn controller::IntoPersistor> {
     match std::env::var("KAFKA_BROKER") {
         Ok(val) => Box::new(UnifyMessageManager::new_and_run(&val).unwrap()),
-        Err(_) => Box::new(MockPersistor::new())
+        Err(_) => Box::new(MockPersistor::new()),
     }
 }
 
@@ -70,7 +70,6 @@ pub(super) struct MockPersistor {
 }
 impl MockPersistor {
     pub(super) fn new() -> Self {
-
         Self {
             //orders: Vec::new(),
             //trades: Vec::new(),
@@ -84,7 +83,7 @@ fn get_market_base_and_quote(market: &str) -> (String, String) {
     (splits[0].to_owned(), splits[1].to_owned())
 }
 
-impl Drop for MockPersistor{
+impl Drop for MockPersistor {
     fn drop(&mut self) {
         let output_file_name = "output.txt";
         let mut file = File::create(output_file_name).unwrap();
@@ -94,7 +93,7 @@ impl Drop for MockPersistor{
         }
         log::info!("output done")
         //rust file need not to be closed manually
-    }    
+    }
 }
 
 impl market::PersistExector for &mut MockPersistor {

--- a/src/message/consumer.rs
+++ b/src/message/consumer.rs
@@ -217,3 +217,27 @@ impl<U> From<U> for SyncTyped<U> {
         Typed::from(Synced::from(t))
     }
 }
+
+pub trait SimpleMessageHandler: Send {
+    fn on_message(&self, msg: &BorrowedMessage<'_>);
+    fn on_no_msg(&self){}
+}
+
+pub struct Simple<U>(U);
+
+impl<U> From<U> for Simple<U> {
+    fn from(t: U) -> Self {
+        Simple(t)
+    }
+}
+
+impl<'c, C: RdConsumerExt, U: SimpleMessageHandler> MessageHandlerAsync<'c, C> for Simple<U> {
+    fn on_message(&self, msg: &BorrowedMessage<'c>, _cr: &'c C::SelfType) -> PinBox<dyn futures::Future<Output = ()> + Send>{
+        self.0.on_message(msg);
+        Box::pin(async {})
+    }
+    fn on_no_msg(&self, _cr: &'c C::SelfType) -> PinBox<dyn futures::Future<Output = ()> + Send>{
+        self.0.on_no_msg();
+        Box::pin(async {})
+    }
+}

--- a/src/message/consumer.rs
+++ b/src/message/consumer.rs
@@ -220,7 +220,7 @@ impl<U> From<U> for SyncTyped<U> {
 
 pub trait SimpleMessageHandler: Send {
     fn on_message(&self, msg: &BorrowedMessage<'_>);
-    fn on_no_msg(&self){}
+    fn on_no_msg(&self) {}
 }
 
 pub struct Simple<U>(U);
@@ -232,11 +232,11 @@ impl<U> From<U> for Simple<U> {
 }
 
 impl<'c, C: RdConsumerExt, U: SimpleMessageHandler> MessageHandlerAsync<'c, C> for Simple<U> {
-    fn on_message(&self, msg: &BorrowedMessage<'c>, _cr: &'c C::SelfType) -> PinBox<dyn futures::Future<Output = ()> + Send>{
+    fn on_message(&self, msg: &BorrowedMessage<'c>, _cr: &'c C::SelfType) -> PinBox<dyn futures::Future<Output = ()> + Send> {
         self.0.on_message(msg);
         Box::pin(async {})
     }
-    fn on_no_msg(&self, _cr: &'c C::SelfType) -> PinBox<dyn futures::Future<Output = ()> + Send>{
+    fn on_no_msg(&self, _cr: &'c C::SelfType) -> PinBox<dyn futures::Future<Output = ()> + Send> {
         self.0.on_no_msg();
         Box::pin(async {})
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -116,8 +116,8 @@ impl<T: producer::MessageScheme> MessageManager for RdProducerStub<T> {
     }
 }
 
-//pub type ChannelMessageManager = RdProducerStub<producer::SimpleMessageScheme>;
-pub type ChannelMessageManager = RdProducerStub<producer::FullOrderMessageScheme>;
+pub type ChannelMessageManager = RdProducerStub<producer::SimpleMessageScheme>;
+//pub type ChannelMessageManager = RdProducerStub<producer::FullOrderMessageScheme>;
 pub type UnifyMessageManager = RdProducerStub<producer::FullOrderMessageScheme>;
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -90,6 +90,8 @@ impl KafkaMessageSender {
         let producer = ClientConfig::new()
             .set("bootstrap.servers", brokers)
             .set("queue.buffering.max.ms", "1")
+            //max.in.flight.requests.per.connection, 1
+            //enable.idempotence yes ?
             .create_with_context(SimpleProducerContext)?;
         let arc = Arc::new(producer);
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,41 +1,13 @@
 use crate::market::Order;
-use crate::types::{OrderEventType, SimpleResult};
-use core::cell::RefCell;
-
-use anyhow::{anyhow, Result};
-use crossbeam_channel::RecvTimeoutError;
-use rdkafka::client::ClientContext;
-use rdkafka::config::ClientConfig;
-use rdkafka::error::{KafkaError, RDKafkaErrorCode};
-use rdkafka::producer::{BaseProducer, BaseRecord, DeliveryResult, Producer, ProducerContext};
-
+use crate::types::OrderEventType;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use std::collections::LinkedList;
-use std::sync::Arc;
-use std::thread;
-use std::time::{Duration, Instant};
-
 pub mod consumer;
+pub mod producer;
 pub mod persist;
 
-pub struct SimpleProducerContext;
-impl ClientContext for SimpleProducerContext {}
-impl ProducerContext for SimpleProducerContext {
-    type DeliveryOpaque = ();
-    fn delivery(&self, result: &DeliveryResult, _: Self::DeliveryOpaque) {
-        match result {
-            // TODO: how to handle this err
-            Err(e) => log::error!("kafka send err: {:?}", e),
-            Ok(_r) => {
-                // log::info!("kafka send done: {:?}", r)
-            }
-        }
-    }
-}
-pub const ORDERS_TOPIC: &str = "orders";
-pub const TRADES_TOPIC: &str = "trades";
-pub const BALANCES_TOPIC: &str = "balances";
+pub use producer::{ORDERS_TOPIC, TRADES_TOPIC, BALANCES_TOPIC};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BalanceMessage {
@@ -56,159 +28,15 @@ pub struct OrderMessage {
     pub quote: String,
 }
 
-// https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
-// TODO: better naming?
-// TODO: change push_order_message etc interface to this enum class?
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(tag = "type", content = "value")]
-pub enum Message {
-    BalanceMessage(Box<BalanceMessage>),
-    OrderMessage(Box<OrderMessage>),
-    TradeMessage(Box<Trade>),
-}
-
 //re-export from market, act as TradeMessage
 pub use crate::market::Trade;
 
+//TODO: senderstatus is not used anymore?
 #[derive(Serialize, Deserialize)]
 pub struct MessageSenderStatus {
     trades_len: usize,
     orders_len: usize,
     balances_len: usize,
-}
-
-pub struct KafkaMessageSender {
-    producer: Arc<BaseProducer<SimpleProducerContext>>,
-    orders_list: RefCell<LinkedList<String>>,
-    trades_list: RefCell<LinkedList<String>>,
-    balances_list: RefCell<LinkedList<String>>,
-    receiver: crossbeam_channel::Receiver<(&'static str, String)>,
-}
-
-impl KafkaMessageSender {
-    pub fn new(brokers: &str, receiver: crossbeam_channel::Receiver<(&'static str, String)>) -> Result<KafkaMessageSender> {
-        let producer = ClientConfig::new()
-            .set("bootstrap.servers", brokers)
-            .set("queue.buffering.max.ms", "1")
-            //max.in.flight.requests.per.connection, 1
-            //enable.idempotence yes ?
-            .create_with_context(SimpleProducerContext)?;
-        let arc = Arc::new(producer);
-
-        Ok(KafkaMessageSender {
-            producer: arc,
-            trades_list: RefCell::new(LinkedList::new()),
-            orders_list: RefCell::new(LinkedList::new()),
-            balances_list: RefCell::new(LinkedList::new()),
-            receiver,
-        })
-    }
-    pub fn on_message(&self, topic_name: &str, message: &str) -> SimpleResult {
-        log::debug!("KAFKA: push {} message: {}", topic_name, message);
-        let mut list = match topic_name {
-            BALANCES_TOPIC => self.balances_list.borrow_mut(),
-            TRADES_TOPIC => self.trades_list.borrow_mut(),
-            ORDERS_TOPIC => self.orders_list.borrow_mut(),
-            _ => unreachable!(),
-        };
-
-        // busy, so not push message now
-        if !list.is_empty() {
-            list.push_back(message.to_string());
-            return Ok(());
-        }
-        let record = BaseRecord::to(topic_name).key("").payload(message);
-        let result = self.producer.send(record);
-        if result.is_err() {
-            log::error!("fail to push message {} to {}", message, topic_name);
-            if let Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), _)) = result {
-                list.push_back(message.to_string());
-                return Ok(());
-            }
-            return Err(anyhow!("kafka push err"));
-        }
-        Ok(())
-    }
-    pub fn finish(self) -> SimpleResult {
-        self.flush();
-        self.producer.flush(std::time::Duration::from_millis(1000));
-        drop(self);
-        Ok(())
-    }
-
-    // if kafka is full, queue messages in list, so here flush them.
-    fn flush_list(&self, topic_name: &str) {
-        let mut list = match topic_name {
-            BALANCES_TOPIC => self.balances_list.borrow_mut(),
-            TRADES_TOPIC => self.trades_list.borrow_mut(),
-            ORDERS_TOPIC => self.orders_list.borrow_mut(),
-            _ => unreachable!(),
-        };
-        for message in list.iter() {
-            let result = self.producer.send(BaseRecord::to(topic_name).key("").payload(message.as_str()));
-
-            if result.is_err() {
-                // log::error!("fail to push message {} to {}", message_str, topic_name);
-                if let Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), _)) = result {
-                    break;
-                }
-            }
-        }
-        list.clear();
-    }
-
-    fn flush(&self) {
-        self.flush_list(BALANCES_TOPIC);
-        self.flush_list(ORDERS_TOPIC);
-        self.flush_list(TRADES_TOPIC);
-        self.producer.poll(Duration::from_millis(0));
-    }
-
-    pub fn start(self) {
-        let mut last_flush_time = Instant::now();
-        let flush_interval = std::time::Duration::from_millis(100);
-        let timeout_interval = std::time::Duration::from_millis(100);
-        loop {
-            if self.is_block() {
-                log::warn!("kafka sender buffer is full");
-                // skip receiving from channel, so main server can know something goes wrong
-                // sleep to avoid cpu 100% usage
-                thread::sleep(flush_interval);
-            } else {
-                match self.receiver.recv_timeout(timeout_interval) {
-                    Ok((topic, message)) => {
-                        self.on_message(topic, &message).ok();
-                    }
-                    Err(RecvTimeoutError::Timeout) => {}
-                    Err(RecvTimeoutError::Disconnected) => {
-                        log::info!("kafka producer disconnected");
-                        break;
-                    }
-                }
-            }
-            let now = Instant::now();
-            if now > last_flush_time + flush_interval {
-                self.flush();
-                last_flush_time = now;
-            }
-        }
-        self.finish().ok();
-        log::info!("kafka sender exit");
-    }
-
-    pub fn is_block(&self) -> bool {
-        self.trades_list.borrow_mut().len() >= 100
-            || self.orders_list.borrow_mut().len() >= 100
-            || self.balances_list.borrow_mut().len() >= 100
-    }
-
-    pub fn status(&self) -> MessageSenderStatus {
-        MessageSenderStatus {
-            trades_len: self.trades_list.borrow_mut().len(),
-            orders_len: self.orders_list.borrow_mut().len(),
-            balances_len: self.balances_list.borrow_mut().len(),
-        }
-    }
 }
 
 pub trait MessageManager {
@@ -219,18 +47,39 @@ pub trait MessageManager {
     fn push_balance_message(&mut self, balance: &BalanceMessage);
 }
 
-pub struct ChannelMessageManager {
+pub struct RdProducerStub<T> {
     pub sender: crossbeam_channel::Sender<(&'static str, String)>,
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl ChannelMessageManager {
+impl<T> RdProducerStub<T>{
     fn push_message_and_topic(&self, message: String, topic_name: &'static str) {
         //log::debug!("KAFKA: push {} message: {}", topic_name, message);
         self.sender.try_send((topic_name, message)).unwrap();
     }
 }
 
-impl MessageManager for ChannelMessageManager {
+impl<T: producer::MessageScheme + 'static> RdProducerStub<T> {
+
+    pub fn new_and_run(brokers: &str) -> Result<Self> {
+        //now the channel is just need to provide a small buffer which is 
+        //enough to accommodate a pluse request in some time slice of thread
+        let (sender, receiver) = crossbeam_channel::bounded(16);
+
+        let producer_context : producer::RdProducerContext<T> = Default::default();
+
+        let kafkaproducer = producer_context.new_producer(brokers)?;
+        std::thread::spawn(move || {
+            producer::RdProducerContext::<T>::run_default(kafkaproducer, receiver);
+        });
+        Ok(Self { 
+            sender,
+            _phantom: std::marker::PhantomData,
+         })
+    }
+}
+
+impl<T: producer::MessageScheme> MessageManager for RdProducerStub<T>  {
     /*
     fn push_message(&mut self, msg: &Message) {
         match msg {
@@ -251,7 +100,8 @@ impl MessageManager for ChannelMessageManager {
     */
 
     fn is_block(&self) -> bool {
-        self.sender.len() >= (self.sender.capacity().unwrap() as f64 * 0.9) as usize
+        self.sender.is_full()
+        //self.sender.len() >= (self.sender.capacity().unwrap() as f64 * 0.9) as usize
     }
     fn push_order_message(&mut self, order: &OrderMessage) {
         let message = serde_json::to_string(&order).unwrap();
@@ -266,6 +116,20 @@ impl MessageManager for ChannelMessageManager {
         self.push_message_and_topic(message, BALANCES_TOPIC)
     }
 }
+
+pub type ChannelMessageManager = RdProducerStub<producer::SimpleMessageScheme>;
+
+// https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
+// TODO: better naming?
+// TODO: change push_order_message etc interface to this enum class?
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", content = "value")]
+pub enum Message {
+    BalanceMessage(Box<BalanceMessage>),
+    OrderMessage(Box<OrderMessage>),
+    TradeMessage(Box<Trade>),
+}
+
 
 pub struct DummyMessageManager {
     // debug purpose only
@@ -300,9 +164,5 @@ impl MessageManager for DummyMessageManager {
 }
 
 pub fn new_message_manager_with_kafka_backend(brokers: &str) -> Result<ChannelMessageManager> {
-    let (sender, receiver) = crossbeam_channel::bounded(100);
-    let kafka_sender = KafkaMessageSender::new(brokers, receiver)?;
-    // TODO: join handle?
-    std::thread::spawn(move || kafka_sender.start());
-    Ok(ChannelMessageManager { sender })
+    ChannelMessageManager::new_and_run(brokers)
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -7,7 +7,7 @@ pub mod consumer;
 pub mod producer;
 pub mod persist;
 
-pub use producer::{ORDERS_TOPIC, TRADES_TOPIC, BALANCES_TOPIC};
+pub use producer::{ORDERS_TOPIC, TRADES_TOPIC, BALANCES_TOPIC, UNIFY_TOPIC};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BalanceMessage {
@@ -117,7 +117,9 @@ impl<T: producer::MessageScheme> MessageManager for RdProducerStub<T>  {
     }
 }
 
-pub type ChannelMessageManager = RdProducerStub<producer::SimpleMessageScheme>;
+//pub type ChannelMessageManager = RdProducerStub<producer::SimpleMessageScheme>;
+pub type ChannelMessageManager = RdProducerStub<producer::FullOrderMessageScheme>;
+pub type UnifyMessageManager = RdProducerStub<producer::FullOrderMessageScheme>;
 
 // https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
 // TODO: better naming?
@@ -130,7 +132,7 @@ pub enum Message {
     TradeMessage(Box<Trade>),
 }
 
-
+/*
 pub struct DummyMessageManager {
     // debug purpose only
     pub keep_data: bool,
@@ -162,6 +164,7 @@ impl MessageManager for DummyMessageManager {
         }
     }
 }
+*/
 
 pub fn new_message_manager_with_kafka_backend(brokers: &str) -> Result<ChannelMessageManager> {
     ChannelMessageManager::new_and_run(brokers)

--- a/src/message/producer.rs
+++ b/src/message/producer.rs
@@ -1,25 +1,27 @@
-use crossbeam_channel::{TryRecvError, RecvTimeoutError};
+use anyhow::Result;
+use crossbeam_channel::{RecvTimeoutError, TryRecvError};
 use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::producer::{BaseProducer, BaseRecord, DeliveryResult, Producer, ProducerContext};
 use rdkafka::util::{IntoOpaque, Timeout};
-use anyhow::Result;
 use std::time::Duration;
 
 pub type SimpleDeliverResult = Result<(), KafkaError>;
 
-pub trait MessageScheme : Default{
-    type DeliverOpaque : IntoOpaque;
+pub trait MessageScheme: Default {
+    type DeliverOpaque: IntoOpaque;
     type K: Into<String>;
     type V: Into<String>;
 
-    fn settings() -> Vec<(Self::K, Self::V)> {vec![]}
+    fn settings() -> Vec<(Self::K, Self::V)> {
+        vec![]
+    }
     fn is_full(&self) -> bool;
     fn on_message(&mut self, title_tip: &'static str, message: String);
-    fn pop_up(&mut self)-> Option<BaseRecord<'_, str, str, Self::DeliverOpaque>>;
+    fn pop_up(&mut self) -> Option<BaseRecord<'_, str, str, Self::DeliverOpaque>>;
     fn commit(&mut self, isfailed: Option<Self::DeliverOpaque>);
-    fn deliver_commit(&mut self, result :SimpleDeliverResult, opaque: Self::DeliverOpaque);
+    fn deliver_commit(&mut self, result: SimpleDeliverResult, opaque: Self::DeliverOpaque);
 }
 
 pub struct RdProducerContext<T: MessageScheme> {
@@ -31,10 +33,9 @@ pub struct RdProducerContext<T: MessageScheme> {
 
 impl<T: MessageScheme> Default for RdProducerContext<T> {
     fn default() -> Self {
-
         let (s, r) = crossbeam_channel::unbounded();
 
-        Self{
+        Self {
             delivery_record: s,
             delivery_record_get: r,
         }
@@ -45,58 +46,55 @@ impl<T: MessageScheme> ClientContext for RdProducerContext<T> {}
 impl<T: MessageScheme> ProducerContext for RdProducerContext<T> {
     type DeliveryOpaque = T::DeliverOpaque;
     fn delivery(&self, result: &DeliveryResult, opaque: Self::DeliveryOpaque) {
-        self.delivery_record.send((
-            match result.as_ref() {
-                Err((err, _)) => Err(err.clone()),
-                Ok(_) => Ok(())
-            },
-            opaque)).ok();
+        self.delivery_record
+            .send((
+                match result.as_ref() {
+                    Err((err, _)) => Err(err.clone()),
+                    Ok(_) => Ok(()),
+                },
+                opaque,
+            ))
+            .ok();
     }
 }
-
 
 //provide a running kafka producer instance which keep sending message under the full-ordering scheme
 //it simply block the Sender side of crossbeam_channel when the deliver queue is full, and quit
 //only when the sender side is closed
 impl<T: MessageScheme> RdProducerContext<T> {
-
     pub fn new_producer(self, brokers: &str) -> Result<BaseProducer<Self>> {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", brokers);
-        T::settings().into_iter().for_each(|item|{
+        T::settings().into_iter().for_each(|item| {
             let (k, v) = item;
-            config.set(k ,v);
+            config.set(k, v);
         });
 
         let producer = config.create_with_context(self)?;
         Ok(producer)
     }
 
-    pub fn run_default(producer: BaseProducer<Self>, 
-        receiver: crossbeam_channel::Receiver<(&'static str, String)>){
-        
+    pub fn run_default(producer: BaseProducer<Self>, receiver: crossbeam_channel::Receiver<(&'static str, String)>) {
         let message_scheme = T::default();
         Self::run(producer, message_scheme, receiver);
     }
 
-    pub fn run(producer: BaseProducer<Self>, mut message_scheme: T,
-        receiver: crossbeam_channel::Receiver<(&'static str, String)>){
-
+    pub fn run(producer: BaseProducer<Self>, mut message_scheme: T, receiver: crossbeam_channel::Receiver<(&'static str, String)>) {
         Self::run_loop(&producer, &mut message_scheme, receiver);
 
-        //flush producer before exit 
+        //flush producer before exit
         while let Some(msg) = message_scheme.pop_up() {
-            let send_ret = match producer.send(msg){
+            let send_ret = match producer.send(msg) {
                 Ok(_) => None,
                 Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), rec)) => {
                     //when queue is full, simply made some polling and retry
                     producer.poll(Duration::from_millis(100));
                     Some(rec.delivery_opaque)
-                },
+                }
                 Err((err, _)) => {
                     log::error!("kafka encounter error when shutdown: {}", err);
                     //TODO: so what should we do? try handling / waiting or just quit?
-                    return
+                    return;
                 }
             };
             message_scheme.commit(send_ret);
@@ -106,33 +104,29 @@ impl<T: MessageScheme> RdProducerContext<T> {
         log::info!("kafka producer running terminated");
     }
 
-    fn run_loop(producer: &BaseProducer<Self>, 
-        message_scheme: &mut T,
-        receiver: crossbeam_channel::Receiver<(&'static str, String)>){
-        
+    fn run_loop(producer: &BaseProducer<Self>, message_scheme: &mut T, receiver: crossbeam_channel::Receiver<(&'static str, String)>) {
         let timeout_interval = Duration::from_millis(100);
         let delivery_report = &producer.context().delivery_record_get;
-        let mut last_poll : i32 = 0;
+        let mut last_poll: i32 = 0;
         let mut producer_queue_full = false;
 
         loop {
             //current implement in mod.rs lead to arbitrary dropping of messages
-            //in the flush() method, I try to fix it here ... 
-            //basically, it should be enough to make use of the ability of 
+            //in the flush() method, I try to fix it here ...
+            //basically, it should be enough to make use of the ability of
             //crossbeam_channel to achieve effectly managing on buffer status,
             //so we can just stop receiving when the queue has fulled
 
             //first, always keep absorbing messages
             let scheme_full = message_scheme.is_full();
             if !scheme_full {
-                let recv_ret = if last_poll == 0 { 
-                    receiver.try_recv() 
-                }else {
-                    receiver.recv_timeout(timeout_interval)
-                        .map_err(|err| match err {
-                            RecvTimeoutError::Timeout => TryRecvError::Empty,
-                            RecvTimeoutError::Disconnected => TryRecvError::Disconnected,
-                        })
+                let recv_ret = if last_poll == 0 {
+                    receiver.try_recv()
+                } else {
+                    receiver.recv_timeout(timeout_interval).map_err(|err| match err {
+                        RecvTimeoutError::Timeout => TryRecvError::Empty,
+                        RecvTimeoutError::Disconnected => TryRecvError::Disconnected,
+                    })
                 };
                 match recv_ret {
                     Ok((topic, message)) => {
@@ -141,25 +135,21 @@ impl<T: MessageScheme> RdProducerContext<T> {
                     Err(TryRecvError::Empty) => {}
                     Err(TryRecvError::Disconnected) => {
                         log::info!("kafka producer disconnected");
-                        return
-                    }               
+                        return;
+                    }
                 };
             }
             //then try send out some messages...
-            let pop_msg = if !producer_queue_full {
-                message_scheme.pop_up()
-            }else {
-                None
-            };
+            let pop_msg = if !producer_queue_full { message_scheme.pop_up() } else { None };
             if let Some(msg) = pop_msg {
-                let send_ret = match producer.send(msg){
+                let send_ret = match producer.send(msg) {
                     Ok(_) => None,
                     Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), rec)) => {
                         //flag is clear when we had polled something
                         producer_queue_full = true;
                         log::warn!("kafka sender buffer is full");
                         Some(rec.delivery_opaque)
-                    },
+                    }
                     Err((err, rec)) => {
                         log::info!("kafka producer encounter error {}", err);
                         Some(rec.delivery_opaque)
@@ -168,21 +158,19 @@ impl<T: MessageScheme> RdProducerContext<T> {
                 message_scheme.commit(send_ret);
             }
             //finally, always poll
-            let poll_dur = if scheme_full && last_poll == 0{
+            let poll_dur = if scheme_full && last_poll == 0 {
                 timeout_interval
-            }else {
+            } else {
                 Duration::from_millis(0)
             };
             last_poll = producer.poll(poll_dur);
             producer_queue_full = producer_queue_full && last_poll == 0;
-            while let Ok((result, opaque)) = delivery_report.try_recv(){
+            while let Ok((result, opaque)) = delivery_report.try_recv() {
                 message_scheme.deliver_commit(result, opaque);
             }
         }
-        
     }
 }
-
 
 pub const ORDERS_TOPIC: &str = "orders";
 pub const TRADES_TOPIC: &str = "trades";
@@ -208,9 +196,7 @@ impl MessageScheme for SimpleMessageScheme {
         vec![("queue.buffering.max.ms", "1")]
     }
     fn is_full(&self) -> bool {
-        self.trades_list.len() >= 100
-        || self.orders_list.len() >= 100
-        || self.balances_list.len() >= 100
+        self.trades_list.len() >= 100 || self.orders_list.len() >= 100 || self.balances_list.len() >= 100
     }
 
     fn on_message(&mut self, title_tip: &'static str, message: String) {
@@ -220,11 +206,11 @@ impl MessageScheme for SimpleMessageScheme {
             ORDERS_TOPIC => &mut self.orders_list,
             _ => unreachable!(),
         };
-        
+
         list.push_back(message);
     }
 
-    fn pop_up(&mut self)-> Option<BaseRecord<'_, str, str, Self::DeliverOpaque>> {
+    fn pop_up(&mut self) -> Option<BaseRecord<'_, str, str, Self::DeliverOpaque>> {
         //we select the list with most size (so message stream is never ordering)
         let mut len = self.balances_list.len();
         let mut list = &mut self.balances_list;
@@ -240,11 +226,11 @@ impl MessageScheme for SimpleMessageScheme {
                 list = *l;
                 topic_name = tp_name;
             }
-        };
+        }
 
-        self.last_poped = list.pop_front().map(|str|{(topic_name, str)});
+        self.last_poped = list.pop_front().map(|str| (topic_name, str));
 
-        self.last_poped.as_ref().map(|poped_ret|{
+        self.last_poped.as_ref().map(|poped_ret| {
             let (topic_name, str) = poped_ret;
             BaseRecord::to(topic_name).key("").payload(AsRef::as_ref(str))
         })
@@ -256,15 +242,13 @@ impl MessageScheme for SimpleMessageScheme {
             let (topic_name, str) = self.last_poped.take().unwrap();
             self.on_message(topic_name, str);
         }
-
     }
-    fn deliver_commit(&mut self, result :SimpleDeliverResult, _opaque: Self::DeliverOpaque) {
+    fn deliver_commit(&mut self, result: SimpleDeliverResult, _opaque: Self::DeliverOpaque) {
         if let Err(e) = result {
             log::error!("kafka send err: {}, MESSAGE LOST", e);
         }
     }
 }
-
 
 #[derive(Default)]
 pub struct FullOrderMessageScheme {
@@ -282,11 +266,13 @@ impl MessageScheme for FullOrderMessageScheme {
     fn settings() -> Vec<(Self::K, Self::V)> {
         //with these semantics the message written into kafka should be
         //strictly ordering as input
-        vec![("enable.idempotence", "true"),
-        ("max.in.flight.requests.per.connection", "1"),
-        //message being tried to send never timeout in ~24days and until 2^31 retries
-        //if it stil failed the underlying connection must be investigated
-        ("delivery.timeout.ms", "2147483647")] 
+        vec![
+            ("enable.idempotence", "true"),
+            ("max.in.flight.requests.per.connection", "1"),
+            //message being tried to send never timeout in ~24days and until 2^31 retries
+            //if it stil failed the underlying connection must be investigated
+            ("delivery.timeout.ms", "2147483647"),
+        ]
     }
     fn is_full(&self) -> bool {
         self.ordered_list.len() >= 100
@@ -296,26 +282,28 @@ impl MessageScheme for FullOrderMessageScheme {
         self.ordered_list.push_back((title_tip, message));
     }
 
-    fn pop_up(&mut self)-> Option<BaseRecord<'_, str, str, Self::DeliverOpaque>> {
+    fn pop_up(&mut self) -> Option<BaseRecord<'_, str, str, Self::DeliverOpaque>> {
         if self.ordered_list.is_empty() {
             return None;
         }
         let (title_tip, message) = self.ordered_list.front().unwrap();
-        Some(BaseRecord::with_opaque_to(UNIFY_TOPIC, Box::new(self.deliver_cnt))
-            .key(*title_tip).payload(AsRef::as_ref(message)))
+        Some(
+            BaseRecord::with_opaque_to(UNIFY_TOPIC, Box::new(self.deliver_cnt))
+                .key(*title_tip)
+                .payload(AsRef::as_ref(message)),
+        )
     }
 
     fn commit(&mut self, isfailed: Option<Self::DeliverOpaque>) {
         if isfailed.is_none() {
             self.ordered_list.pop_front();
             self.deliver_cnt += 1;
-        }else {
+        } else {
             //sanity check
             assert!(*isfailed.unwrap() == self.deliver_cnt);
         }
-
     }
-    fn deliver_commit(&mut self, result :SimpleDeliverResult, opaque: Self::DeliverOpaque) {
+    fn deliver_commit(&mut self, result: SimpleDeliverResult, opaque: Self::DeliverOpaque) {
         //sanity check: verify we are keeping order
         assert!(*opaque == self.commited_cnt);
         self.commited_cnt += 1;

--- a/src/message/producer.rs
+++ b/src/message/producer.rs
@@ -1,0 +1,149 @@
+use crate::market::Order;
+use crate::types::{OrderEventType, SimpleResult};
+use core::cell::RefCell;
+
+use anyhow::{anyhow, Result};
+use crossbeam_channel::RecvTimeoutError;
+use rdkafka::client::ClientContext;
+use rdkafka::config::ClientConfig;
+use rdkafka::error::{KafkaError, RDKafkaErrorCode};
+use rdkafka::producer::{BaseProducer, BaseRecord, DeliveryResult, Producer, ProducerContext};
+use rdkafka::message::{ToBytes}
+
+use serde::{Deserialize, Serialize};
+
+use std::collections::LinkedList;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub mod consumer;
+pub mod persist;
+
+pub struct SimpleProducerContext;
+impl ClientContext for SimpleProducerContext {}
+impl ProducerContext for SimpleProducerContext {
+    type DeliveryOpaque = ();
+    fn delivery(&self, result: &DeliveryResult, _: Self::DeliveryOpaque) {
+        match result {
+            // TODO: how to handle this err
+            Err(e) => log::error!("kafka send err: {:?}", e),
+            Ok(_r) => {
+                // log::info!("kafka send done: {:?}", r)
+            }
+        }
+    }
+}
+pub const ORDERS_TOPIC: &str = "orders";
+pub const TRADES_TOPIC: &str = "trades";
+pub const BALANCES_TOPIC: &str = "balances";
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BalanceMessage {
+    pub timestamp: f64,
+    pub user_id: u32,
+    pub asset: String,
+    pub business: String,
+    pub change: String,
+    pub balance: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OrderMessage {
+    pub event: OrderEventType,
+    pub order: Order,
+    pub base: String,
+    pub quote: String,
+}
+
+// https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
+// TODO: better naming?
+// TODO: change push_order_message etc interface to this enum class?
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", content = "value")]
+pub enum Message {
+    BalanceMessage(Box<BalanceMessage>),
+    OrderMessage(Box<OrderMessage>),
+    TradeMessage(Box<Trade>),
+}
+
+//re-export from market, act as TradeMessage
+pub use crate::market::Trade;
+
+#[derive(Serialize, Deserialize)]
+pub struct MessageSenderStatus {
+    trades_len: usize,
+    orders_len: usize,
+    balances_len: usize,
+}
+
+pub trait MessageSenderScheme : ProducerContext {
+    type KeyType: ToBytes + ?Sized
+    fn on_message(&self, title_tip: &str, message: &str) -> 
+        BaseRecord<'_, Self::KeyType, String, Self::DeliveryOpaque>
+    fn on_send_queue_full(&self, BaseRecord<'_, Self::KeyType, String, Self::DeliveryOpaque>)
+}
+
+pub trait ClientContextWithSettings : ClientContext {
+    fn settings<K: Into<String>, V: Into<String>>() -> [(K, V)]
+}
+
+//provide a running kafka producer instance which keep sending message under the full-ordering scheme
+//it simply block the Sender side of crossbeam_channel when the deliver queue is full, and quit
+//only when the sender side is closed
+pub struct RdProducerRunner<T: MessageSenderScheme> {
+    producer: BaseProducer<T>,
+    receiver: crossbeam_channel::Receiver<(&'static str, String)>,
+}
+
+impl<T: MessageSenderScheme> RdProducerRunner<T> {
+    pub fn new(brokers: &str, receiver: crossbeam_channel::Receiver<(&'static str, String)>) -> Result<KafkaMessageSender> {
+        let producer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("queue.buffering.max.ms", "1")
+            .set("enable.idempotence", "yes")
+            .create_with_context(SimpleProducerContext)?;
+        let arc = Arc::new(producer);
+
+        Ok(KafkaMessageSender {
+            producer: arc,
+            trades_list: RefCell::new(LinkedList::new()),
+            orders_list: RefCell::new(LinkedList::new()),
+            balances_list: RefCell::new(LinkedList::new()),
+            receiver,
+        })
+    }
+
+    pub fn run(self) {
+        let mut last_flush_time = Instant::now();
+        let flush_interval = std::time::Duration::from_millis(100);
+        let timeout_interval = std::time::Duration::from_millis(100);
+        loop {
+            if self.is_block() {
+                log::warn!("kafka sender buffer is full");
+                // skip receiving from channel, so main server can know something goes wrong
+                // sleep to avoid cpu 100% usage
+                thread::sleep(flush_interval);
+            } else {
+                match self.receiver.recv_timeout(timeout_interval) {
+                    Ok((topic, message)) => {
+                        self.on_message(topic, &message).ok();
+                    }
+                    Err(RecvTimeoutError::Timeout) => {}
+                    Err(RecvTimeoutError::Disconnected) => {
+                        log::info!("kafka producer disconnected");
+                        break;
+                    }
+                }
+            }
+            let now = Instant::now();
+            if now > last_flush_time + flush_interval {
+                self.flush();
+                last_flush_time = now;
+            }
+        }
+        self.finish().ok();
+        log::info!("kafka sender exit");
+    }    
+}


### PR DESCRIPTION
This complete the feature described in #114 

+ I have rewritten the kafka sender module so it could suffer from less message lost, and can obtain completely no-missing, ordering message stream with suitable configure flags to the kafka client.

+ As discussed in the issues, now an unify messenger would write all messages into the same topic in their origin order, and being distinguished by their keys.

+ Instead of the js script, I provide a rust version (bin/test_unifymessenger) to fetch data from mq and write data into file. It also show how the consumer framework can work besides persisting:

     + To do the test, first set the environment variable: `KAFKA_BROKER=<kafka broker address>`

     + then launch a test:

            > cargo test --features emit_state_diff

     + the test data would be sent to kafka's 'unifyevent' topic instead of the output.txt file

     + Then we can run test_unifymessenger to collect the data to output.txt.

+ Some traits has implied and adapted onto the mock persistor in the testing in market module. So the test can use the newly unify messenger to record the data instead write them to file directly.