### PR TITLE
feature: post_only order

### DIFF
--- a/migrations/20210514142408_add_post_only_to_order_slice.sql
+++ b/migrations/20210514142408_add_post_only_to_order_slice.sql
@@ -1,3 +1,3 @@
 -- Add migration script here
 
-ALTER TABLE order_slice ADD COLUMN post_only BOOL;
+ALTER TABLE order_slice ADD COLUMN post_only BOOL default false;

--- a/migrations/20210514142408_add_post_only_to_order_slice.sql
+++ b/migrations/20210514142408_add_post_only_to_order_slice.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+
+ALTER TABLE order_slice ADD COLUMN post_only BOOL;

--- a/proto/exchange/matchengine.proto
+++ b/proto/exchange/matchengine.proto
@@ -151,6 +151,7 @@ message OrderPutRequest {
   string price = 6;  // should be empty or zero for market order
   string taker_fee = 7;
   string maker_fee = 8;
+  bool post_only = 9; // Ensures an Limit order is subjected to Maker Fees (ignored for Market orders).
 }
 
 message OrderInfo {
@@ -169,6 +170,7 @@ message OrderInfo {
   string finished_base = 13;
   string finished_quote = 14;
   string finished_fee = 15;
+  bool post_only = 16;
 }
 
 message OrderQueryRequest {

--- a/proto/exchange/matchengine.proto
+++ b/proto/exchange/matchengine.proto
@@ -151,7 +151,7 @@ message OrderPutRequest {
   string price = 6;  // should be empty or zero for market order
   string taker_fee = 7;
   string maker_fee = 8;
-  bool post_only = 9; // Ensures an Limit order is subjected to Maker Fees (ignored for Market orders).
+  bool post_only = 9; // Ensures an Limit order is only subject to Maker Fees (ignored for Market orders).
 }
 
 message OrderInfo {

--- a/src/matchengine/dto.rs
+++ b/src/matchengine/dto.rs
@@ -35,6 +35,7 @@ pub fn order_to_proto(o: &market::Order) -> OrderInfo {
         finished_base: o.finished_base.to_string(),
         finished_quote: o.finished_quote.to_string(),
         finished_fee: o.finished_fee.to_string(),
+        post_only: o.post_only,
     }
 }
 
@@ -64,5 +65,6 @@ pub fn order_input_from_proto(req: &OrderPutRequest) -> Result<market::OrderInpu
             Decimal::from_str(req.maker_fee.as_str())?
         },
         market: req.market.clone(),
+        post_only: req.post_only,
     })
 }

--- a/src/matchengine/market.rs
+++ b/src/matchengine/market.rs
@@ -710,7 +710,8 @@ impl Market {
         }
 
         if need_cancel {
-            // now only self trade orders will be canceled here
+            // Now both self trade orders and immediately triggered post_only
+            // limit orders will be cancelled here.
             persistor.put_order(&taker, OrderEventType::FINISH);
         } else if taker.type_ == OrderType::MARKET {
             // market order can either filled or not

--- a/src/matchengine/persist.rs
+++ b/src/matchengine/persist.rs
@@ -153,6 +153,7 @@ pub async fn load_slice_from_db(conn: &mut ConnectionType, slice_id: i64, contro
                 finished_base: order.finished_base,
                 finished_quote: order.finished_quote,
                 finished_fee: order.finished_fee,
+                post_only: order.post_only,
             };
             market.insert_order(order);
         }
@@ -331,6 +332,7 @@ pub async fn dump_orders(conn: &mut ConnectionType, slice_id: i64, controller: &
                 finished_base: order.finished_base,
                 finished_quote: order.finished_quote,
                 finished_fee: order.finished_fee,
+                post_only: order.post_only,
             }
         });
 

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -169,6 +169,7 @@ pub struct OrderSlice {
     pub finished_base: DecimalDbType,
     pub finished_quote: DecimalDbType,
     pub finished_fee: DecimalDbType,
+    pub post_only: bool,
 }
 
 // xx_id here means the last persisted entry id


### PR DESCRIPTION
Closes #100 

As mentioned in a [reference link](https://help.coinbase.com/en/pro/trading-and-funding/orders/overview-of-order-types-and-settings-stop-limit-market) of the issue:

>Post Only will ensure that your limit order is posted to the order book and sits on the order book to be charged a Maker Fees if it is filled. If any part of the order would execute immediately due to its price when arriving at the matching engine, the entire order will be rejected. This is useful for ensuring that an order is not subject to Taker Fees, if desired.
