### PR TITLE
Pass true to parameter verbose for log display in `monitor_kafka_message`

### DIFF
--- a/examples/js/monitor_kafka_message.js
+++ b/examples/js/monitor_kafka_message.js
@@ -3,7 +3,7 @@ import Dotenv from "dotenv";
 
 async function main() {
   Dotenv.config();
-  const consumer = new KafkaConsumer(true).Init();
+  const consumer = new KafkaConsumer().Init(true);
   await consumer;
 }
 


### PR DESCRIPTION
Part of #162 
***Has not checked db changes for update_balance & put_order.***

With this fix, the log will be displayed as below.
```
node monitor_kafka_message.js

New message: {
  topic: 'balances',
  partition: 0,
  offset: '30',
  value: '{"timestamp":1622600015.0,"user_id":3,"asset":"USDT","business":"deposit","change":"10000000.0","balance":"100000000.0","detail":"{\\"key\\":\\"value\\",\\"id\\":1622600015085}"}'
}
New message: {
  topic: 'balances',
  partition: 0,
  offset: '31',
  value: '{"timestamp":1622600015.0,"user_id":3,"asset":"ETH","business":"deposit","change":"50000.0","balance":"500000.0","detail":"{\\"key\\":\\"value\\",\\"id\\":1622600015109}"}'
}
```