### PR TITLE
Replace `env_logger` with tokio non-blocking tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,17 +305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
 dependencies = [
  "num-traits 0.2.14",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -609,7 +607,6 @@ dependencies = [
  "config",
  "crossbeam-channel",
  "dotenv",
- "env_logger",
  "futures",
  "futures-channel",
  "futures-core",
@@ -635,6 +632,9 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "ttl_cache",
 ]
 
@@ -663,19 +663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1137,6 +1124,15 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -1730,6 +1726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,6 +1955,15 @@ dependencies = [
  "cpuid-bool",
  "digest",
  "opaque-debug",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2211,15 +2225,6 @@ dependencies = [
  "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -2512,6 +2517,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +2555,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde 1.0.124",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde 1.0.124",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2768,15 +2827,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ chrono = { version = "0.4.19", features = [ "serde" ] }
 config_rs = { package = "config", version = "0.10.1" }
 crossbeam-channel = "0.5.0"
 dotenv = "0.15.0"
-env_logger = "0.8.3"
 futures = "0.3.13"
 futures-channel = "0.3.13"
 futures-core = { version = "0.3.13", default-features = false }
@@ -38,6 +37,9 @@ thiserror = "1.0.24"
 thread-id = "3.3.0"
 tokio = { version = "1.6.0", features = [ "full" ] }
 tonic = "0.4.0"
+tracing = "0.1"
+tracing-appender = "0.1"
+tracing-subscriber = "0.2"
 ttl_cache = "0.5.1"
 
 [build-dependencies]

--- a/src/bin/matchengine.rs
+++ b/src/bin/matchengine.rs
@@ -16,7 +16,13 @@ use sqlx::Connection;
 
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init();
+
+    let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(non_blocking)
+        .init();
+
     let rt: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/src/bin/persistor.rs
+++ b/src/bin/persistor.rs
@@ -15,7 +15,12 @@ use message::persist::{self, TopicConfig, MIGRATOR};
 
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init();
+
+    let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(non_blocking)
+        .init();
 
     let mut conf = config_rs::Config::new();
     let config_file = dotenv::var("CONFIG_FILE").unwrap();

--- a/src/bin/restapi.rs
+++ b/src/bin/restapi.rs
@@ -27,7 +27,13 @@ async fn ping(_req: HttpRequest, _data: web::Data<AppState>) -> impl Responder {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv::dotenv().ok();
-    env_logger::init();
+
+    let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(non_blocking)
+        .init();
+
     let mut conf = config_rs::Config::new();
     let config_file = dotenv::var("CONFIG_FILE").unwrap();
     conf.merge(config_rs::File::with_name(&config_file)).unwrap();

--- a/src/bin/test_unifymessenger.rs
+++ b/src/bin/test_unifymessenger.rs
@@ -37,7 +37,12 @@ impl SimpleMessageHandler for &MessageWriter {
 
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init();
+
+    let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(non_blocking)
+        .init();
 
     let mut conf = config_rs::Config::new();
     let config_file = dotenv::var("CONFIG_FILE").unwrap();


### PR DESCRIPTION
Closes #115 

As discussion in this issue, replaces `env_logger` with tokio non-blocking tracing.
Other code places calling `log` macros (as `log::info!`) should not been fixed, since [tracing-log](https://github.com/tokio-rs/tracing/tree/master/tracing-log) is enabled by default.

With this fix, the output log is similar with `env_logger` as below.
```
Jun 13 12:38:19.372  INFO dingir_exchange::matchengine::persist::state_save_load: replay balance_update {"user_id":3,"asset":"USDT","business":"deposit","business_id":1623587503830,"delta":"100.0","detail":"{\"key\":\"value\"}"}    
Jun 13 12:38:19.373 DEBUG dingir_exchange::matchengine::asset::update_controller: change user balance: 3 USDT 100.0    
Jun 13 12:38:19.373  INFO dingir_exchange::matchengine::persist::state_save_load: replay balance_update {"user_id":3,"asset":"ETH","business":"deposit","business_id":1623587503836,"delta":"50.0","detail":"{\"key\":\"value\"}"}    
Jun 13 12:38:19.375 DEBUG dingir_exchange::matchengine::asset::update_controller: change user balance: 3 ETH 50.0    
Jun 13 12:38:19.375  INFO dingir_exchange::matchengine::persist::state_save_load: replay balance_update {"user_id":4,"asset":"USDT","business":"deposit","business_id":1623587503854,"delta":"100.0","detail":"{\"key\":\"value\"}"}    
```