### PR TITLE
Separate config file to development and staging `RUN_MODE`s

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
+RUN_MODE=development # development or staging
 RUST_BACKTRACE=1
-CONFIG_FILE=config.yaml
 RUST_LOG=dingir_exchange=debug,restapi=debug
-#RUST_LOG=info
-#RUST_LOG=debug
+# RUST_LOG=info
+# RUST_LOG=debug

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,6 @@
+slice_interval: 3600
+slice_keeptime: 259200
+disable_self_trade: true
+disable_market_order: true
+check_eddsa_signatue: auto
+user_order_num_limit: 1000

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -2,9 +2,3 @@ debug: true
 db_log: postgres://exchange:exchange_AA9944@127.0.0.1/exchange 
 db_history: postgres://exchange:exchange_AA9944@127.0.0.1/exchange 
 brokers: '127.0.0.1:9092'
-slice_interval: 3600
-slice_keeptime: 259200
-disable_self_trade: true
-disable_market_order: true
-check_eddsa_signatue: auto
-user_order_num_limit: 1000

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,0 +1,4 @@
+debug: true
+db_log: postgres://exchange:exchange_AA9944@exchange-pq/exchange 
+db_history: postgres://exchange:exchange_AA9944@exchange-pq/exchange 
+brokers: 'exchange-kafka:9092'

--- a/src/bin/matchengine.rs
+++ b/src/bin/matchengine.rs
@@ -37,10 +37,7 @@ fn main() {
 }
 
 async fn prepare() -> anyhow::Result<GrpcHandler> {
-    let mut conf = config_rs::Config::new();
-    let config_file = dotenv::var("CONFIG_FILE")?;
-    conf.merge(config_rs::File::with_name(&config_file)).unwrap();
-    let mut settings: config::Settings = conf.try_into().unwrap();
+    let mut settings = config::Settings::new();
     log::debug!("Settings: {:?}", settings);
 
     let mut conn = ConnectionType::connect(&settings.db_log).await?;

--- a/src/bin/persistor.rs
+++ b/src/bin/persistor.rs
@@ -22,10 +22,7 @@ fn main() {
         .with_writer(non_blocking)
         .init();
 
-    let mut conf = config_rs::Config::new();
-    let config_file = dotenv::var("CONFIG_FILE").unwrap();
-    conf.merge(config_rs::File::with_name(&config_file)).unwrap();
-    let settings: config::Settings = conf.try_into().unwrap();
+    let settings = config::Settings::new();
     log::debug!("Settings: {:?}", settings);
 
     let rt: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/bin/restapi.rs
+++ b/src/bin/restapi.rs
@@ -34,16 +34,11 @@ async fn main() -> std::io::Result<()> {
         .with_writer(non_blocking)
         .init();
 
-    let mut conf = config_rs::Config::new();
-    let config_file = dotenv::var("CONFIG_FILE").unwrap();
-    conf.merge(config_rs::File::with_name(&config_file)).unwrap();
-
-    let restapi_cfg: Option<config_rs::Value> = conf.get("restapi").ok();
-
-    let dburl = conf.get_str("db_history").unwrap();
+    // TODO: Should add another `config/restapi.yaml` for this target?
+    let dburl = dingir_exchange::config::Settings::new().db_history;
     log::debug!("Prepared db connection: {}", &dburl);
 
-    let config: restapi::config::Settings = restapi_cfg.and_then(|v| v.try_into().ok()).unwrap_or_else(Default::default);
+    let config = restapi::config::Settings::default();
 
     let manage_channel = if let Some(ep_str) = &config.manage_endpoint {
         log::info!("Connect to manage channel {}", ep_str);

--- a/src/bin/test_unifymessenger.rs
+++ b/src/bin/test_unifymessenger.rs
@@ -45,10 +45,7 @@ fn main() {
         .with_writer(non_blocking)
         .init();
 
-    let mut conf = config_rs::Config::new();
-    let config_file = dotenv::var("CONFIG_FILE").unwrap();
-    conf.merge(config_rs::File::with_name(&config_file)).unwrap();
-    let settings: config::Settings = conf.try_into().unwrap();
+    let settings = config::Settings::new();
     log::debug!("Settings: {:?}", settings);
 
     let rt: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use config_rs::{Config, File};
 use rust_decimal::Decimal;
 use serde::de;
 use serde::{Deserialize, Serialize};
@@ -147,5 +148,20 @@ impl Default for Settings {
             check_eddsa_signatue: OrderSignatrueCheck::None,
             user_order_num_limit: 1000,
         }
+    }
+}
+
+impl Settings {
+    pub fn new() -> Self {
+        // Initializes with `config/default.yaml`.
+        let mut conf = Config::default();
+        conf.merge(File::with_name("config/default")).unwrap();
+
+        // Merges with `config/RUN_MODE.yaml` (development as default).
+        let run_mode = dotenv::var("RUN_MODE").unwrap_or_else(|_| "development".into());
+        conf.merge(File::with_name(&format!("config/{}", run_mode)).required(false))
+            .unwrap();
+
+        conf.try_into().unwrap()
     }
 }


### PR DESCRIPTION
References `config_rs` example: https://github.com/mehcode/config-rs/tree/master/examples/hierarchical-env/config

1. Adds ENV `RUN_MODE`, it could be set to `development` and `staging` for now.
2. Moves the code of reading config file to `Settings::new` method. It could be easily invoked for executable code in `src/bin`.
3. Deletes some code and leaves a TODO in `src/bin/restapi.rs`, since I could not find `restapi` configuration (will fix it if it is wrong).