### PR TITLE
Remove unnecessary variable initialization in test suite

### DIFF
--- a/examples/js/tick.ts
+++ b/examples/js/tick.ts
@@ -106,7 +106,6 @@ async function cancelAll() {
   }
 }
 async function run() {
-  let cnt = 0;
   for (let cnt = 0; ; cnt++) {
     try {
       await sleep(1000);


### PR DESCRIPTION
The variable initialization is already done by the for loop on the next line.