### PR TITLE
Remove unneeded, data-heavy files from docker build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+orchestra
+target/release
+target/debug
+examples
+logs
+src
+Cargo*


### PR DESCRIPTION
When building a release docker image, the entire project root directory is sent to the docker daemon (which could potentially run on another machine).
This can become quite big and even problematic if the build process is started with a user that doesn't have access to some directories (especially the volumes in orchestra).

Fortunately, most of the project root directory isn't even needed for the docker process. All the docker image requires is the `config` folder and the binary stored directly in the `target` folder.