### PR TITLE
Fix duration parse issue in trade view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
+ "humantime",
  "humantime-serde",
  "hyper",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-channel = "0.3.13"
 futures-core = { version = "0.3.13", default-features = false }
 futures-util = { version = "0.3.13", default-features = false }
 hex = "0.4.3"
+humantime = "2.1.0"
 humantime-serde = "1.0.1"
 hyper = "0.14.4"
 itertools = "0.10.0"

--- a/src/openapi/tradingview.rs
+++ b/src/openapi/tradingview.rs
@@ -4,6 +4,7 @@ use crate::restapi::errors::RpcError;
 use crate::restapi::types::{KlineReq, KlineResult, TickerResult};
 use crate::restapi::{mock, state};
 use actix_web::Responder;
+use humantime::parse_duration;
 use paperclip::actix::web::{self, HttpRequest, Json};
 use paperclip::actix::{api_v2_operation, Apiv2Schema};
 use serde::{Deserialize, Serialize};
@@ -381,8 +382,7 @@ pub async fn ticker(
     app_state: web::Data<state::AppState>,
 ) -> Result<Json<TickerResult>, actix_web::Error> {
     let (ticker_inv, market_name) = path.into_inner();
-    let ticker_inv: TickerInv = serde_json::from_str(&ticker_inv).unwrap();
-    let ticker_inv = ticker_inv.0;
+    let ticker_inv = parse_duration(&ticker_inv).unwrap();
 
     let cache = req.app_data::<state::AppCache>().expect("App cache not found");
     let now_ts: DateTime<Utc> = SystemTime::now().into();


### PR DESCRIPTION
Test this on `ff3` (update `fluidex-backend` with `openapi`, and replace all `restapi` with `openapi` in frontend). It seems there is no other issues.

<img width="800" alt="2" src="https://user-images.githubusercontent.com/31645658/131752522-1a02465a-d637-4b4c-9612-fb984dc270a1.png">